### PR TITLE
workflow fixes

### DIFF
--- a/.github/workflows/project-gtests.yml
+++ b/.github/workflows/project-gtests.yml
@@ -59,7 +59,7 @@ jobs:
           sudo make install
 
       - name: Build CMake project
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DLMP_ENABLE_CUDA=ON -DLMP_ENABLE_TEST=ON
 
       - name: Build lamppp module
         run: cmake --build build --config Debug --parallel
@@ -72,5 +72,5 @@ jobs:
 
       - name: Run GTests
         run: |
-          build/autograd_tests
-          build/tensor_tests
+          build/build/autograd_tests
+          build/build/tensor_tests

--- a/.github/workflows/project-pytests.yml
+++ b/.github/workflows/project-pytests.yml
@@ -56,7 +56,7 @@ jobs:
           poetry install
 
       - name: Build CMake project
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DLMP_ENABLE_CUDA=ON -DLMP_ENABLE_TEST=ON
 
       - name: Build lamppp module
         run: cmake --build build --target lamppp --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,12 @@ target_link_libraries(lamppp INTERFACE autograd_core tensor_core nets_core)
 
 add_subdirectory(docs/examples)
 add_subdirectory(csrc/bindings)
-add_subdirectory(tests)
-add_subdirectory(benchmarks)
+if(LMP_ENABLE_TEST)
+  add_subdirectory(tests)
+endif()
+if(LMP_ENABLE_BENCH)
+  add_subdirectory(benchmarks)
+endif()
 
 # INSTALLATION ---------------------------------
 install(

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -1,10 +1,11 @@
 
+requirements: 
+- need to export a python module: already done.
+- need to figure out how to LINK the cpp .so file to the module
+- finally need to figure out how to export said module WITH the pybind.
+- preferrably uses poetry
 
-<!-- - decision: do I keep the unique_ptr OR do I do shared ptr? 
-- default behavior: do I want Modules to be COPIABLE, or one-to-many PIMPL type deal? -->
 
-- do I want maps to AnyModule (type erased interface) OR to a shared_ptr<ModuleImpl>???
-- so we DO need a ptr() function that returns a pointer (based on ModuleImpl) to the actual type
-
-
-- so we just have a virtual function in Placeholder, concrete impl in Holder, and a interface method in AnyModule
+ok. we want poetry to STAY as our package manager
+we want to replicate the pyproject.toml and CMakeLists.txt inside of scikit_build_example
+we want to install that.


### PR DESCRIPTION
## Summary by Sourcery

Refine the build and CI setups by adding conditional test and benchmark inclusion in CMake, enabling CUDA and test flags in GitHub workflows, correcting test binary paths, and updating project notes with workflow and packaging requirements

Build:
- Make inclusion of tests and benchmarks conditional on LMP_ENABLE_TEST and LMP_ENABLE_BENCH options in CMakeLists.txt

CI:
- Enable CUDA and test builds by default in CI workflows
- Fix GTest binary invocation paths in the project-gtests workflow

Documentation:
- Revise NOTES.md to document Python module export requirements, C++ linkage, PyBind integration, and Poetry usage