### PR TITLE
[refactor] added infer_meta

### DIFF
--- a/csrc/include/lamppp/tensor/infer_meta.hpp
+++ b/csrc/include/lamppp/tensor/infer_meta.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstddef>
+#include <vector>
+#include "lamppp/tensor/data_type.hpp"
+
+namespace lmp::tensor {
+class TensorImpl;
+namespace detail {
+
+struct OpMeta {
+  DataType dtype;
+  size_t size;
+  std::vector<size_t> shape;
+  bool expand;
+};
+
+OpMeta infer_unary (const TensorImpl* a);
+OpMeta infer_binary(const TensorImpl* a, const TensorImpl* b);
+OpMeta infer_reduct(const TensorImpl* a, size_t axis);
+
+}  // namespace detail
+}  // namespace lmp::tensor

--- a/csrc/src/tensor/CMakeLists.txt
+++ b/csrc/src/tensor/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TENSOR_SOURCES
   tensor.cpp
   tensor_impl.cpp
   storage.cpp
+  infer_meta.cpp
   utils/align_utils.cpp
 )
 

--- a/csrc/src/tensor/cpu/meta_handler.cpp
+++ b/csrc/src/tensor/cpu/meta_handler.cpp
@@ -1,16 +1,17 @@
 #include "lamppp/tensor/cpu/meta_handler.hpp"
 #include "lamppp/common/assert.hpp"
 #include "lamppp/tensor/device_type.hpp"
+#include "lamppp/tensor/infer_meta.hpp"
 
 namespace lmp::tensor::detail {
 
 template <>
-UnaryMetaHandler::TensorMetaHandler(const TensorImpl* a)
-    : inTens_({a}),
-      outDtype_(a->type()),
-      outSize_(a->numel()),
-      outShape_(a->shape()),
-      expand_(false) {
+UnaryMetaHandler::TensorMetaHandler(const TensorImpl* a) : inTens_({a}) {
+  OpMeta m = infer_unary(a);
+  outDtype_ = m.dtype;
+  outSize_ = m.size;
+  outShape_ = m.shape;
+  expand_ = m.expand;
   LMP_DISPATCH_ALL_TYPES(outDtype_, [&] {
     using out_dtype_t = scalar_t;
     LMP_DISPATCH_ALL_TYPES(a->type(), [&] {
@@ -23,19 +24,12 @@ UnaryMetaHandler::TensorMetaHandler(const TensorImpl* a)
 
 template <>
 BinaryMetaHandler::TensorMetaHandler(const TensorImpl* a, const TensorImpl* b)
-    : inTens_({a, b}),
-      outDtype_(type_upcast(a->type(), b->type())),
-      outSize_(a->numel()),
-      outShape_(a->shape()),
-      expand_(false) {
-  LMP_INTERNAL_ASSERT(a->device() == b->device())
-      << "Should have asserted already";
-  expand_ = (a->shape() != b->shape());
-  if (expand_) {
-    detail::AlignUtil expand_dims(a->shape(), b->shape());
-    outSize_ = expand_dims.aligned_size_;
-    outShape_ = expand_dims.aligned_shape_;
-  }
+    : inTens_({a, b}) {
+  OpMeta m = infer_binary(a, b);
+  outDtype_ = m.dtype;
+  outSize_ = m.size;
+  outShape_ = m.shape;
+  expand_ = m.expand;
 
   LMP_DISPATCH_ALL_TYPES(outDtype_, [&] {
     using out_dtype_t = scalar_t;
@@ -59,13 +53,12 @@ BinaryMetaHandler::TensorMetaHandler(const TensorImpl* a, const TensorImpl* b)
 
 template <>
 ReductMetaHandler::TensorMetaHandler(const TensorImpl* a, size_t axis)
-    : inTens_({a}),
-      outDtype_(a->type()),
-      outSize_(a->numel()),
-      outShape_(a->shape()),
-      expand_(false) {
-  outSize_ /= outShape_[axis];
-  outShape_[axis] = 1;
+    : inTens_({a}) {
+  OpMeta m = infer_reduct(a, axis);
+  outDtype_ = m.dtype;
+  outSize_ = m.size;
+  outShape_ = m.shape;
+  expand_ = m.expand;
   LMP_DISPATCH_ALL_TYPES(outDtype_, [&] {
     using out_dtype_t = scalar_t;
     LMP_DISPATCH_ALL_TYPES(a->type(), [&] {

--- a/csrc/src/tensor/infer_meta.cpp
+++ b/csrc/src/tensor/infer_meta.cpp
@@ -1,0 +1,45 @@
+#include "lamppp/tensor/infer_meta.hpp"
+#include "lamppp/common/assert.hpp"
+#include "lamppp/tensor/data_type.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
+#include "lamppp/tensor/utils/align_utils.hpp"
+
+namespace lmp::tensor::detail {
+
+OpMeta infer_unary(const TensorImpl* a) {
+  OpMeta m;
+  m.dtype = a->type();
+  m.size = a->numel();
+  m.shape = a->shape();
+  m.expand = false;
+  return m;
+}
+
+OpMeta infer_binary(const TensorImpl* a, const TensorImpl* b) {
+  LMP_INTERNAL_ASSERT(a->device() == b->device())
+      << "Should have asserted already";
+  OpMeta m;
+  m.dtype = type_upcast(a->type(), b->type());
+  m.size = a->numel();
+  m.shape = a->shape();
+  m.expand = (a->shape() != b->shape());
+  if (m.expand) {
+    detail::AlignUtil expand_dims(a->shape(), b->shape());
+    m.size = expand_dims.aligned_size_;
+    m.shape = expand_dims.aligned_shape_;
+  }
+  return m;
+}
+
+OpMeta infer_reduct(const TensorImpl* a, size_t axis) {
+  OpMeta m;
+  m.dtype = a->type();
+  m.size = a->numel();
+  m.shape = a->shape();
+  m.expand = false;
+  m.size /= m.shape[axis];
+  m.shape[axis] = 1;
+  return m;
+}
+
+}  // namespace lmp::tensor::detail


### PR DESCRIPTION
we separate logic inferring the shape from TensorMetaHandler, because in the future LazyFunction will need to depend on it. 

we probably want to do something to TensorMetaHandler at some point, the current state right now is highly entangled (responsible for shape, and storage allocation?)