### PR TITLE
[tensor] Part 1.1 #4 — TensorImpl tolerates a zero-byte storage

### DIFF
--- a/csrc/src/tensor/tensor_impl.cpp
+++ b/csrc/src/tensor/tensor_impl.cpp
@@ -18,7 +18,8 @@ TensorImpl::TensorImpl(Storage storage, const std::vector<size_t>& shape,
                            : std::accumulate(shape.begin(), shape.end(), 1,
                                              std::multiplies<>())) {
   LMP_DISPATCH_ALL_TYPES(dtype, [&] {
-    LMP_CHECK(data_.byte_size() / sizeof(scalar_t) == numel_)
+    LMP_CHECK(data_.byte_size() == 0 ||
+              data_.byte_size() / sizeof(scalar_t) == numel_)
         << "Storage size mismatch: expected " << numel_ << " elements of type "
         << dtype << " (" << sizeof(scalar_t) << " bytes each), but storage has "
         << data_.byte_size() << " bytes (capacity for "


### PR DESCRIPTION
Part 1.1 item 4 of 5.

The `TensorImpl(Storage, shape, dtype)` ctor asserted `byte_size()/sizeof == numel_`. A deferred tensor carries a zero-byte `Storage` but a real shape, which trips it. Relaxed the `LMP_CHECK` to:

```cpp
data_.byte_size() == 0 || data_.byte_size() / sizeof(scalar_t) == numel_
```

Deferred (0-byte, numel>0) now passes; a genuinely wrong-sized non-empty storage still fails; already-empty tensors unaffected.

**Zero behavioral change** — nothing today constructs a 0-byte/non-zero-shape impl.