### PR TITLE
[tensor] Part 1.1 #5 — make data() non-const (future realization chokepoint)

### DIFF
--- a/csrc/include/lamppp/tensor/tensor.hpp
+++ b/csrc/include/lamppp/tensor/tensor.hpp
@@ -43,7 +43,7 @@ class Tensor {
                   DataType dtype = DEFAULT_DTYPE)
       : impl_(std::make_shared<TensorImpl>(data, shape, device, dtype)) {}
 
-  void* data() const noexcept;
+  void* data();
   DataType type() const noexcept;
   DeviceType device() const noexcept;
   const std::vector<size_t>& shape() const noexcept;
@@ -56,7 +56,7 @@ class Tensor {
     std::vector<T> converted_data(impl_->numel());
     LMP_DISPATCH_ALL_TYPES(impl_->type(), [&] {
       std::unique_ptr<scalar_t[]> original_data = std::make_unique<scalar_t[]>(numel());
-      ops::copy_stub()(device(), DeviceType::CPU, data(),
+      ops::copy_stub()(device(), DeviceType::CPU, impl_->data(),
                                   original_data.get(), numel(), type(), type());
 
       for (size_t i = 0; i < impl_->numel(); ++i) {

--- a/csrc/include/lamppp/tensor/tensor_impl.hpp
+++ b/csrc/include/lamppp/tensor/tensor_impl.hpp
@@ -69,7 +69,7 @@ class TensorImpl {
                       DataType dtype);
   /// @endinternal
 
-  void* data() const noexcept;
+  void* data();
   DataType type() const noexcept;
   DeviceType device() const noexcept;
   const std::vector<size_t>& shape() const noexcept;

--- a/csrc/src/tensor/cpu/binary.cpp
+++ b/csrc/src/tensor/cpu/binary.cpp
@@ -28,8 +28,8 @@ void binary_dispatch_handler(BinaryMetaHandler& meta, Args&&... args) {
         binary_kernel_launcher(
             internal::PtrPack<out_dtype_t, arg1_dtype_t, arg2_dtype_t>(
                 static_cast<out_dtype_t*>(meta.out().data()),
-                static_cast<arg1_dtype_t*>(meta.in()[0]->data()),
-                static_cast<arg2_dtype_t*>(meta.in()[1]->data())),
+                static_cast<arg1_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data()),
+                static_cast<arg2_dtype_t*>(const_cast<TensorImpl*>(meta.in()[1])->data())),
             OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
             meta.out().numel());
       });

--- a/csrc/src/tensor/cpu/expand.cpp
+++ b/csrc/src/tensor/cpu/expand.cpp
@@ -31,8 +31,8 @@ void expand_dispatch_handler(BinaryMetaHandler& meta, Args&&... args) {
         expand_kernel_launcher(
             internal::PtrPack<out_dtype_t, arg1_dtype_t, arg2_dtype_t>(
                 static_cast<out_dtype_t*>(meta.out().data()),
-                static_cast<arg1_dtype_t*>(meta.in()[0]->data()),
-                static_cast<arg2_dtype_t*>(meta.in()[1]->data())),
+                static_cast<arg1_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data()),
+                static_cast<arg2_dtype_t*>(const_cast<TensorImpl*>(meta.in()[1])->data())),
             OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
             meta.out().numel(),
             static_cast<const CPUOffsetUtil<kNArgs>*>(meta.offset()));

--- a/csrc/src/tensor/cpu/kernels.cpp
+++ b/csrc/src/tensor/cpu/kernels.cpp
@@ -62,7 +62,7 @@ TensorImpl transpose_cpu(const TensorImpl& a) {
   return LMP_DISPATCH_ALL_TYPES(a.type(), [&] {
     Storage c_storage(m * n * sizeof(scalar_t), DeviceType::CPU);
     ::lmp::tensor::detail::cpu::cpuTranspose<scalar_t>(
-        static_cast<const scalar_t*>(a.data()),
+        static_cast<const scalar_t*>(const_cast<TensorImpl&>(a).data()),
         static_cast<scalar_t*>(c_storage.data()), m, n);
     return TensorImpl(c_storage, {n, m}, out_dtype);
   });
@@ -88,8 +88,8 @@ TensorImpl matmul_cpu(const TensorImpl& a, const TensorImpl& b) {
         using out_type_t = scalar_t;
         Storage c_storage(m * n * sizeof(out_type_t), DeviceType::CPU);
         ::lmp::tensor::detail::cpu::cpuMatMul<a_type_t, b_type_t, out_type_t>(
-            static_cast<const a_type_t*>(a.data()),
-            static_cast<const b_type_t*>(b.data()),
+            static_cast<const a_type_t*>(const_cast<TensorImpl&>(a).data()),
+            static_cast<const b_type_t*>(const_cast<TensorImpl&>(b).data()),
             static_cast<out_type_t*>(c_storage.data()), m, n, k);
         return TensorImpl(c_storage, {m, n}, out_dtype);
       });
@@ -127,8 +127,8 @@ TensorImpl conv1d_cpu(const TensorImpl& input, const TensorImpl& kernel,
 
         ::lmp::tensor::detail::cpu::cpuConv1d<in_type_t, kern_type_t,
                                               out_type_t>(
-            static_cast<const in_type_t*>(input.data()),
-            static_cast<const kern_type_t*>(kernel.data()),
+            static_cast<const in_type_t*>(const_cast<TensorImpl&>(input).data()),
+            static_cast<const kern_type_t*>(const_cast<TensorImpl&>(kernel).data()),
             static_cast<out_type_t*>(c_storage.data()), stride, padding,
             dilation, input.shape().data(), kernel.shape().data(),
             out_shape.data());
@@ -174,8 +174,8 @@ TensorImpl conv2d_cpu(const TensorImpl& input, const TensorImpl& kernel,
 
         ::lmp::tensor::detail::cpu::cpuConv2d<in_type_t, kern_type_t,
                                               out_type_t>(
-            static_cast<const in_type_t*>(input.data()),
-            static_cast<const kern_type_t*>(kernel.data()),
+            static_cast<const in_type_t*>(const_cast<TensorImpl&>(input).data()),
+            static_cast<const kern_type_t*>(const_cast<TensorImpl&>(kernel).data()),
             static_cast<out_type_t*>(c_storage.data()), stride, padding,
             dilation, input.shape().data(), kernel.shape().data(),
             out_shape.data());
@@ -227,8 +227,8 @@ TensorImpl conv3d_cpu(const TensorImpl& input, const TensorImpl& kernel,
 
         ::lmp::tensor::detail::cpu::cpuConv3d<in_type_t, kern_type_t,
                                               out_type_t>(
-            static_cast<const in_type_t*>(input.data()),
-            static_cast<const kern_type_t*>(kernel.data()),
+            static_cast<const in_type_t*>(const_cast<TensorImpl&>(input).data()),
+            static_cast<const kern_type_t*>(const_cast<TensorImpl&>(kernel).data()),
             static_cast<out_type_t*>(c_storage.data()), stride, padding,
             dilation, input.shape().data(), kernel.shape().data(),
             out_shape.data());

--- a/csrc/src/tensor/cpu/reduct.cpp
+++ b/csrc/src/tensor/cpu/reduct.cpp
@@ -37,7 +37,7 @@ void reduct_dispatch_handler(ReductMetaHandler& meta, size_t axis,
       reduct_kernel_launcher(
           internal::PtrPack<out_dtype_t, arg_dtype_t>(
               static_cast<out_dtype_t*>(meta.out().data()),
-              static_cast<arg_dtype_t*>(meta.in()[0]->data())),
+              static_cast<arg_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data())),
           OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
           meta.out().numel(), axis, meta.in()[0]->shape().data(),
           meta.in()[0]->strides().data(), meta.out().shape().size());

--- a/csrc/src/tensor/cpu/unary.cpp
+++ b/csrc/src/tensor/cpu/unary.cpp
@@ -26,7 +26,7 @@ void unary_dispatch_handler(UnaryMetaHandler& meta, Args&&... args) {
       unary_kernel_launcher(
           internal::PtrPack<out_dtype_t, arg_dtype_t>(
               static_cast<out_dtype_t*>(meta.out().data()),
-              static_cast<arg_dtype_t*>(meta.in()[0]->data())),
+              static_cast<arg_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data())),
           OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
           meta.out().numel());
     });

--- a/csrc/src/tensor/cuda/binary.cu
+++ b/csrc/src/tensor/cuda/binary.cu
@@ -39,8 +39,8 @@ void binary_dispatch_handler(BinaryMetaHandler& meta, Args&&... args) {
         binary_kernel_launcher(
             internal::CUDAPtrPack<out_dtype_t, arg1_dtype_t, arg2_dtype_t>(
                 static_cast<out_dtype_t*>(meta.out().data()),
-                static_cast<arg1_dtype_t*>(meta.in()[0]->data()),
-                static_cast<arg2_dtype_t*>(meta.in()[1]->data())),
+                static_cast<arg1_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data()),
+                static_cast<arg2_dtype_t*>(const_cast<TensorImpl*>(meta.in()[1])->data())),
             OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
             meta.out().numel());
       });

--- a/csrc/src/tensor/cuda/expand.cu
+++ b/csrc/src/tensor/cuda/expand.cu
@@ -44,8 +44,8 @@ void expand_dispatch_handler(BinaryMetaHandler& meta, Args&&... args) {
         expand_kernel_launcher(
             internal::CUDAPtrPack<out_dtype_t, arg1_dtype_t, arg2_dtype_t>(
                 static_cast<out_dtype_t*>(meta.out().data()),
-                static_cast<arg1_dtype_t*>(meta.in()[0]->data()),
-                static_cast<arg2_dtype_t*>(meta.in()[1]->data())),
+                static_cast<arg1_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data()),
+                static_cast<arg2_dtype_t*>(const_cast<TensorImpl*>(meta.in()[1])->data())),
             OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
             meta.out().numel(),
             static_cast<const CUDAOffsetUtil<kNArgs>*>(meta.offset()));

--- a/csrc/src/tensor/cuda/kernels.cu
+++ b/csrc/src/tensor/cuda/kernels.cu
@@ -61,7 +61,7 @@ TensorImpl transpose_cuda(const TensorImpl& a) {
   return LMP_DISPATCH_ALL_TYPES(a.type(), [&] {
     Storage c_storage(m * n * sizeof(scalar_t), DeviceType::CUDA);
     ::lmp::tensor::detail::cuda::cudaTranspose<scalar_t>(
-        static_cast<const scalar_t*>(a.data()),
+        static_cast<const scalar_t*>(const_cast<TensorImpl&>(a).data()),
         static_cast<scalar_t*>(c_storage.data()), m, n);
     return TensorImpl(c_storage, {n, m}, out_dtype);
   });
@@ -87,8 +87,8 @@ TensorImpl matmul_cuda(const TensorImpl& a, const TensorImpl& b) {
         using out_type_t = scalar_t;
         Storage c_storage(m * n * sizeof(out_type_t), DeviceType::CUDA);
         ::lmp::tensor::detail::cuda::cudaMatMul<a_type_t, b_type_t, out_type_t>(
-            static_cast<const a_type_t*>(a.data()),
-            static_cast<const b_type_t*>(b.data()),
+            static_cast<const a_type_t*>(const_cast<TensorImpl&>(a).data()),
+            static_cast<const b_type_t*>(const_cast<TensorImpl&>(b).data()),
             static_cast<out_type_t*>(c_storage.data()), m, n, k);
         return TensorImpl(c_storage, {m, n}, out_dtype);
       });
@@ -126,8 +126,8 @@ TensorImpl conv1d_cuda(const TensorImpl& input, const TensorImpl& kernel,
 
         ::lmp::tensor::detail::cuda::cudaConv1d<in_type_t, kern_type_t,
                                                 out_type_t>(
-            static_cast<const in_type_t*>(input.data()),
-            static_cast<const kern_type_t*>(kernel.data()),
+            static_cast<const in_type_t*>(const_cast<TensorImpl&>(input).data()),
+            static_cast<const kern_type_t*>(const_cast<TensorImpl&>(kernel).data()),
             static_cast<out_type_t*>(c_storage.data()), stride, padding,
             dilation, input.shape().data(), kernel.shape().data(),
             out_shape.data());
@@ -173,8 +173,8 @@ TensorImpl conv2d_cuda(const TensorImpl& input, const TensorImpl& kernel,
 
         ::lmp::tensor::detail::cuda::cudaConv2d<in_type_t, kern_type_t,
                                                 out_type_t>(
-            static_cast<const in_type_t*>(input.data()),
-            static_cast<const kern_type_t*>(kernel.data()),
+            static_cast<const in_type_t*>(const_cast<TensorImpl&>(input).data()),
+            static_cast<const kern_type_t*>(const_cast<TensorImpl&>(kernel).data()),
             static_cast<out_type_t*>(c_storage.data()), stride, padding,
             dilation, input.shape().data(), kernel.shape().data(),
             out_shape.data());
@@ -226,8 +226,8 @@ TensorImpl conv3d_cuda(const TensorImpl& input, const TensorImpl& kernel,
 
         ::lmp::tensor::detail::cuda::cudaConv3d<in_type_t, kern_type_t,
                                                 out_type_t>(
-            static_cast<const in_type_t*>(input.data()),
-            static_cast<const kern_type_t*>(kernel.data()),
+            static_cast<const in_type_t*>(const_cast<TensorImpl&>(input).data()),
+            static_cast<const kern_type_t*>(const_cast<TensorImpl&>(kernel).data()),
             static_cast<out_type_t*>(c_storage.data()), stride, padding,
             dilation, input.shape().data(), kernel.shape().data(),
             out_shape.data());

--- a/csrc/src/tensor/cuda/reduct.cu
+++ b/csrc/src/tensor/cuda/reduct.cu
@@ -50,7 +50,7 @@ void reduct_dispatch_handler(ReductMetaHandler& meta, size_t axis,
       reduct_kernel_launcher(
           internal::CUDAPtrPack<out_dtype_t, arg_dtype_t>(
               static_cast<out_dtype_t*>(meta.out().data()),
-              static_cast<arg_dtype_t*>(meta.in()[0]->data())),
+              static_cast<arg_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data())),
           OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
           meta.out().numel(), axis, meta.in()[0]->shape().data(),
           meta.in()[0]->strides().data(), meta.out().shape().size());

--- a/csrc/src/tensor/cuda/unary.cu
+++ b/csrc/src/tensor/cuda/unary.cu
@@ -33,7 +33,7 @@ void unary_dispatch_handler(UnaryMetaHandler& meta, Args&&... args) {
       unary_kernel_launcher(
           internal::CUDAPtrPack<out_dtype_t, arg_dtype_t>(
               static_cast<out_dtype_t*>(meta.out().data()),
-              static_cast<arg_dtype_t*>(meta.in()[0]->data())),
+              static_cast<arg_dtype_t*>(const_cast<TensorImpl*>(meta.in()[0])->data())),
           OpFunctor<out_dtype_t>(std::forward<Args>(args)...),
           meta.out().numel());
     });

--- a/csrc/src/tensor/native/memory_ops.cpp
+++ b/csrc/src/tensor/native/memory_ops.cpp
@@ -15,7 +15,8 @@ Tensor to(const Tensor& a, DeviceType to_device) {
 
   return LMP_DISPATCH_ALL_TYPES(a.type(), [&]() {
     Storage new_storage(a.numel() * sizeof(scalar_t), to_device);
-    copy_stub()(a.device(), to_device, a.data(), new_storage.data(), a.numel(),
+    copy_stub()(a.device(), to_device, const_cast<Tensor&>(a).data(),
+                new_storage.data(), a.numel(),
                 a.type(), a.type());
     TensorImpl new_impl(new_storage, a.shape(), a.type());
     return detail::UnsafeTensorAccessor::fromImpl(

--- a/csrc/src/tensor/tensor.cpp
+++ b/csrc/src/tensor/tensor.cpp
@@ -3,7 +3,7 @@
 
 namespace lmp::tensor {
 
-void* Tensor::data() const noexcept {
+void* Tensor::data() {
   return impl_->data();
 }
 DataType Tensor::type() const noexcept {

--- a/csrc/src/tensor/tensor_impl.cpp
+++ b/csrc/src/tensor/tensor_impl.cpp
@@ -27,7 +27,7 @@ TensorImpl::TensorImpl(Storage storage, const std::vector<size_t>& shape,
   update_strides();
 }
 
-void* TensorImpl::data() const noexcept {
+void* TensorImpl::data() {
   return data_.data();
 }
 DataType TensorImpl::type() const noexcept {
@@ -104,13 +104,13 @@ Scalar TensorImpl::index(const std::vector<size_t>& idx) {
 // maybe default behavior should be to assign other.type, other.device, other.data COMPLETELY to this
 void TensorImpl::copy(const TensorImpl& other) const {
   LMP_DISPATCH_ALL_TYPES(other.type(), [&] {
-    ops::copy_stub()(other.device(), device(), other.data(), data(),
+    ops::copy_stub()(other.device(), device(), other.data_.data(), data_.data(),
                      other.numel(), other.type(), type());
   });
 }
 
 void TensorImpl::fill(Scalar item) const {
-  ops::fill_stub()(device(), data(), numel(), item, type());
+  ops::fill_stub()(device(), data_.data(), numel(), item, type());
 }
 
 const size_t kMaxPrintElem = 2e1;
@@ -119,7 +119,7 @@ void TensorImpl::print(std::ostream& os) const {
   LMP_DISPATCH_ALL_TYPES(this->type_, [&] {
     size_t print_size = std::min(kMaxPrintElem, this->numel());
     auto* data_ptr = new scalar_t[print_size * sizeof(scalar_t)];
-    ops::copy_stub()(this->device(), DeviceType::CPU, this->data(),
+    ops::copy_stub()(this->device(), DeviceType::CPU, this->data_.data(),
                      static_cast<void*>(data_ptr), print_size, this->type_,
                      this->type_);
     for (size_t i = 0; i < print_size; i++) {


### PR DESCRIPTION
Part 1.1 item 5 of 5.

Drop `const`/`noexcept` from `TensorImpl::data()` and `Tensor::data()` so they can later force realization of a deferred tensor. **No realization logic yet — behavior identical**; goal is only that it compiles with `data()` non-const.

Const-context callers reconciled behavior-preservingly:
- Same-class const methods (`copy`/`fill`/`print`, `to_vector`) route through `data_.data()` / `impl_->data()` (`Storage::data()` stays const).
- Reads through `const TensorImpl*` / `const Tensor&` (elementwise + reduct kernels, plus `transpose/matmul/conv` and `memory_ops::to`) wrapped in `const_cast`, then cast back to `const scalar_t*` for the read.

`Storage::data()` and `autograd::Variable::data()` untouched.

⚠️ The 4 `cuda/*.cu` edits were syntax-mirrored from the `.cpp` sites but **not compiled** (no nvcc in the agent env) — needs a real CUDA build before merge.