### PR TITLE
[inductor] LazyBackend seam + per-device registry (P1)

### DIFF
--- a/csrc/include/lamppp/tensor/lazy/lazy_backend.hpp
+++ b/csrc/include/lamppp/tensor/lazy/lazy_backend.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "lamppp/tensor/device_type.hpp"
+
+namespace lmp::tensor {
+
+class TensorImpl;
+class LazyFunction;
+
+/**
+ * @brief Seam between the tensor module and a lazy (graph-capturing) backend.
+ *
+ * @details This abstract interface lets the `tensor` module hand off realization
+ * of a lazily-captured graph without depending on the `inductor` module. A
+ * concrete backend is registered per device via `register_backend`, and looked
+ * up at runtime via `backend`. The table is keyed by `DeviceType`, mirroring the
+ * dispatch pattern used elsewhere in the module.
+ *
+ * @see DeviceType
+ */
+struct LazyBackend {
+  virtual ~LazyBackend() = default;
+  virtual void realize(TensorImpl*) = 0;
+};
+
+/// @brief Returns the backend registered for `dev`, or nullptr if none.
+LazyBackend* backend(DeviceType dev);
+
+/// @brief Registers `b` as the backend for `dev`, filling its slot.
+void register_backend(DeviceType dev, LazyBackend* b);
+
+}  // namespace lmp::tensor

--- a/csrc/src/tensor/CMakeLists.txt
+++ b/csrc/src/tensor/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TENSOR_SOURCES
   cpu/kernels.cpp
   cpu/memory.cpp
   utils/fill_like.cpp
+  lazy/lazy_backend.cpp
   tensor.cpp
   tensor_impl.cpp
   storage.cpp

--- a/csrc/src/tensor/lazy/lazy_backend.cpp
+++ b/csrc/src/tensor/lazy/lazy_backend.cpp
@@ -1,0 +1,25 @@
+#include "lamppp/tensor/lazy/lazy_backend.hpp"
+
+#include <array>
+
+namespace lmp::tensor {
+
+namespace {
+
+/// @brief Meyers-singleton table holding one backend pointer per device.
+std::array<LazyBackend*, static_cast<size_t>(DeviceType::Count)>& registry() {
+  static std::array<LazyBackend*, static_cast<size_t>(DeviceType::Count)> table{};
+  return table;
+}
+
+}  // namespace
+
+LazyBackend* backend(DeviceType dev) {
+  return registry()[static_cast<size_t>(dev)];
+}
+
+void register_backend(DeviceType dev, LazyBackend* b) {
+  registry()[static_cast<size_t>(dev)] = b;
+}
+
+}  // namespace lmp::tensor


### PR DESCRIPTION
Abstract LazyBackend + backend(dev)/register_backend(dev,*) registry in tensor module. No behavior change; nothing calls it yet.