### PR TITLE
Add GPU CI pipeline using Modal

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -1,0 +1,25 @@
+name: ci-gpu
+
+on:
+  workflow_dispatch:
+
+jobs:
+  modal-gpu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: ">=3.11"
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Run GPU CI on Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: modal run tests/ci/modal_gpu.py

--- a/tests/ci/modal_gpu.py
+++ b/tests/ci/modal_gpu.py
@@ -9,9 +9,7 @@ REMOTE_REPO = "/root/rushlite"
 app = modal.App("rushlite-ci-gpu")
 
 image = (
-    modal.Image.from_registry(
-        "nvidia/cuda:12.8.1-devel-ubuntu24.04", add_python="3.11"
-    )
+    modal.Image.from_registry("nvidia/cuda:12.8.1-devel-ubuntu24.04", add_python="3.11")
     .apt_install(
         "build-essential",
         "cmake",
@@ -45,7 +43,7 @@ def run_gpu_ci() -> None:
     _run("uv sync --extra cu128")
     _run("SKBUILD_CMAKE_DEFINE=LMP_ENABLE_CUDA=ON uv pip install .")
     _run(
-        "uv run python -c \""
+        'uv run python -c "'
         "import pylamp; "
         "pylamp.Tensor([[0.0]], requires_grad=False, "
         "device=pylamp.device.cuda, dtype=pylamp.dtype.float64); "

--- a/tests/ci/modal_gpu.py
+++ b/tests/ci/modal_gpu.py
@@ -1,0 +1,59 @@
+import pathlib
+import subprocess
+
+import modal
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REMOTE_REPO = "/root/rushlite"
+
+app = modal.App("rushlite-ci-gpu")
+
+image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:12.8.1-devel-ubuntu24.04", add_python="3.11"
+    )
+    .apt_install(
+        "build-essential",
+        "cmake",
+        "git",
+        "python3-venv",
+        "python3-pip",
+        "pybind11-dev",
+        "python3-pybind11",
+        "libboost-all-dev",
+    )
+    .pip_install("uv")
+    .add_local_dir(str(REPO_ROOT), REMOTE_REPO, copy=True)
+)
+
+
+def _run(cmd: str) -> None:
+    print(f"\n+ {cmd}", flush=True)
+    subprocess.run(cmd, shell=True, cwd=REMOTE_REPO, check=True)
+
+
+@app.function(gpu="T4", image=image, timeout=60 * 60)
+def run_gpu_ci() -> None:
+    _run("nvidia-smi")
+    _run(
+        "cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug "
+        "-DLMP_ENABLE_CUDA=ON -DLMP_ENABLE_TEST=OFF "
+        "-DLMP_ENABLE_COVERAGE=OFF -DLMP_ENABLE_BENCH=OFF"
+    )
+    _run("cmake --build build --config Debug --parallel")
+    _run("uv lock")
+    _run("uv sync --extra cu128")
+    _run("SKBUILD_CMAKE_DEFINE=LMP_ENABLE_CUDA=ON uv pip install .")
+    _run(
+        "uv run python -c \""
+        "import pylamp; "
+        "pylamp.Tensor([[0.0]], requires_grad=False, "
+        "device=pylamp.device.cuda, dtype=pylamp.dtype.float64); "
+        "print('pylamp CUDA device OK')\""
+    )
+    _run("uv run pytest tests/stress/pytorch_stress_test.py -v")
+
+
+@app.local_entrypoint()
+def main() -> None:
+    run_gpu_ci.remote()


### PR DESCRIPTION
## Summary
This PR adds a GPU-based continuous integration pipeline for the rushlite project using Modal, enabling automated testing of CUDA functionality.

## Key Changes
- Added `tests/ci/modal_gpu.py` - A new Modal-based CI configuration that:
  - Defines a Docker image based on NVIDIA CUDA 12.8.1 with Python 3.11 and all necessary build dependencies (CMake, pybind11, Boost, etc.)
  - Configures a remote GPU function (`run_gpu_ci`) that runs on Modal's T4 GPU infrastructure
  - Executes a complete build and test pipeline including:
    - GPU availability verification via `nvidia-smi`
    - CMake configuration with CUDA support enabled
    - Project compilation in Debug mode
    - Python environment setup via `uv`
    - Package installation with CUDA support
    - CUDA device functionality verification
    - GPU stress testing via pytest

## Implementation Details
- Uses Modal's Python SDK to define infrastructure-as-code for GPU CI
- Copies the entire repository to the remote container for building
- Includes a local entrypoint that triggers the remote GPU function
- Sets a 1-hour timeout to accommodate compilation and testing
- Verifies CUDA integration by instantiating a pylamp Tensor on the CUDA device

https://claude.ai/code/session_01SL9MURUUXeHUEdszfwsUcJ