### PR TITLE
[feat] kernel fusion: master switch + graph partition + realize rewire

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,17 @@ cmake_minimum_required(VERSION 3.24)
 project(lamppp LANGUAGES CXX)
 
 option(LMP_ENABLE_CUDA "Compile with CUDA support" OFF)
+option(LMP_ENABLE_FUSION "Enable kernel fusion (lazy backend registration)" OFF)
 option(LMP_ENABLE_COVERAGE "Enable code coverage" OFF)
 option(LMP_ENABLE_TEST "Enable testing" OFF)
 option(LMP_ENABLE_BENCH "Enable benchmarks" OFF)
 
 if(LMP_ENABLE_CUDA)
   add_definitions(-DLMP_ENABLE_CUDA)
+endif()
+
+if(LMP_ENABLE_FUSION)
+  add_definitions(-DLMP_ENABLE_FUSION)
 endif()
 
 # CORE CONFIG ---------------------------------

--- a/csrc/include/lamppp/inductor/nvrtc/assert.hpp
+++ b/csrc/include/lamppp/inductor/nvrtc/assert.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+#include "lamppp/common/assert.hpp"
+
+#define NVRTC_CHECK(x)                                      \
+  do {                                                      \
+    const nvrtcResult nvrtc_r = (x);                        \
+    LMP_CHECK(nvrtc_r == NVRTC_SUCCESS)                     \
+        << "NVRTC error: " << nvrtcGetErrorString(nvrtc_r); \
+  } while (0)
+
+#define CU_CHECK(x)                                                     \
+  do {                                                                  \
+    const CUresult cu_r = (x);                                          \
+    if (cu_r != CUDA_SUCCESS) {                                         \
+      const char* cu_s = nullptr;                                       \
+      cuGetErrorString(cu_r, &cu_s);                                    \
+      LMP_CHECK(false) << "CUDA driver error: " << (cu_s ? cu_s : "?"); \
+    }                                                                   \
+  } while (0)
+
+#define CUDART_CHECK(x)                                            \
+  do {                                                             \
+    const cudaError_t cudart_r = (x);                              \
+    LMP_CHECK(cudart_r == cudaSuccess)                             \
+        << "CUDA runtime error: " << cudaGetErrorString(cudart_r); \
+  } while (0)

--- a/csrc/include/lamppp/inductor/nvrtc/codegen.hpp
+++ b/csrc/include/lamppp/inductor/nvrtc/codegen.hpp
@@ -1,29 +1,19 @@
 #pragma once
 
+#include <sstream>
 #include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "lamppp/inductor/nvrtc/fused_graph.hpp"
+#include "lamppp/tensor/data_type.hpp"
+#include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
 
 namespace lmp::inductor {
 
-struct FusedGraph;
-
-/**
- * @brief Entry-point symbol of the generated kernel.
- *
- * @details Kernel ABI is (out, in0 .. in{K-1}, n): the output pointer first,
- * then boundary inputs in `FusedGraph::slot` order, then the element count.
- * The future launch piece loads this symbol and binds arguments in this order.
- */
 inline constexpr const char* kFusedKernelName = "fused_kernel";
 
-/**
- * @brief Generate CUDA source for the fused elementwise kernel of `g`.
- *
- * @details Emits one `__global__` function (`kFusedKernelName`) evaluating the
- * whole group element-wise over a flat 1-D index. Every value is declared with
- * its own real dtype; each op promotes its operands to the node's dtype.
- *
- * @pre Every node in `g.order` is a fusible elementwise op.
- */
 std::string codegen_kernel(const FusedGraph& g);
 
-}  // namespace lmp::inductor
+}

--- a/csrc/include/lamppp/inductor/nvrtc/codegen.hpp
+++ b/csrc/include/lamppp/inductor/nvrtc/codegen.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+namespace lmp::inductor {
+
+struct FusedGraph;
+
+/**
+ * @brief Entry-point symbol of the generated kernel.
+ *
+ * @details Kernel ABI is (out, in0 .. in{K-1}, n): the output pointer first,
+ * then boundary inputs in `FusedGraph::slot` order, then the element count.
+ * The future launch piece loads this symbol and binds arguments in this order.
+ */
+inline constexpr const char* kFusedKernelName = "fused_kernel";
+
+/**
+ * @brief Generate CUDA source for the fused elementwise kernel of `g`.
+ *
+ * @details Emits one `__global__` function (`kFusedKernelName`) evaluating the
+ * whole group element-wise over a flat 1-D index. Every value is declared with
+ * its own real dtype; each op promotes its operands to the node's dtype.
+ *
+ * @pre Every node in `g.order` is a fusible elementwise op.
+ */
+std::string codegen_kernel(const FusedGraph& g);
+
+}  // namespace lmp::inductor

--- a/csrc/include/lamppp/inductor/nvrtc/fused_graph.hpp
+++ b/csrc/include/lamppp/inductor/nvrtc/fused_graph.hpp
@@ -6,46 +6,23 @@
 #include <unordered_set>
 #include <vector>
 
-namespace lmp::tensor {
-class TensorImpl;
-}
+#include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/lazy/realize.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
 
 namespace lmp::inductor {
 
-/**
- * @brief A maximal group of fusible deferred ops with its realized boundary.
- *
- * @details The partition of a lazily-captured graph that bottoms out at
- * realized leaves: interior nodes are still-deferred fusible ops in
- * leaves-first evaluation order, and the boundary `inputs` are the realized
- * tensors feeding the group. `slot` is the inverse of `inputs`, giving each
- * boundary input a stable index for kernel-argument binding.
- *
- * @see build_fused_graph
- */
 struct FusedGraph {
-  // Boundary inputs feeding the group: realized leaves. Two views of one bijection.
-  std::vector<tensor::TensorImpl*> inputs;  // index -> impl (ordered)
-  std::unordered_map<tensor::TensorImpl*, size_t> slot;  // impl -> index
+  std::vector<tensor::TensorImpl*> inputs;
+  std::unordered_map<tensor::TensorImpl*, size_t> slot;
 
-  // Interior op-nodes in evaluation order (leaves-first; root last).
   std::vector<tensor::TensorImpl*> order;
 
-  // Classification memo: every node already placed (interior or input).
   std::unordered_set<tensor::TensorImpl*> seen;
 
-  // Result of the group. v0: exactly one (== root). Seam for future multi-output.
   tensor::TensorImpl* output = nullptr;
 };
 
-/**
- * @brief Partition the deferred graph rooted at `root` into a `FusedGraph`.
- *
- * @details Walks the operand DAG from `root`, classifying each non-root node as
- * interior (still deferred and fusible) or boundary input (realized as a side
- * effect). The root is always interior. DAG- and diamond-safe via the `seen`
- * memo.
- */
 FusedGraph build_fused_graph(tensor::TensorImpl* root);
 
-}  // namespace lmp::inductor
+}

--- a/csrc/include/lamppp/inductor/nvrtc/fused_graph.hpp
+++ b/csrc/include/lamppp/inductor/nvrtc/fused_graph.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace lmp::tensor {
+class TensorImpl;
+}
+
+namespace lmp::inductor {
+
+/**
+ * @brief A maximal group of fusible deferred ops with its realized boundary.
+ *
+ * @details The partition of a lazily-captured graph that bottoms out at
+ * realized leaves: interior nodes are still-deferred fusible ops in
+ * leaves-first evaluation order, and the boundary `inputs` are the realized
+ * tensors feeding the group. `slot` is the inverse of `inputs`, giving each
+ * boundary input a stable index for kernel-argument binding.
+ *
+ * @see build_fused_graph
+ */
+struct FusedGraph {
+  // Boundary inputs feeding the group: realized leaves. Two views of one bijection.
+  std::vector<tensor::TensorImpl*> inputs;  // index -> impl (ordered)
+  std::unordered_map<tensor::TensorImpl*, size_t> slot;  // impl -> index
+
+  // Interior op-nodes in evaluation order (leaves-first; root last).
+  std::vector<tensor::TensorImpl*> order;
+
+  // Classification memo: every node already placed (interior or input).
+  std::unordered_set<tensor::TensorImpl*> seen;
+
+  // Result of the group. v0: exactly one (== root). Seam for future multi-output.
+  tensor::TensorImpl* output = nullptr;
+};
+
+/**
+ * @brief Partition the deferred graph rooted at `root` into a `FusedGraph`.
+ *
+ * @details Walks the operand DAG from `root`, classifying each non-root node as
+ * interior (still deferred and fusible) or boundary input (realized as a side
+ * effect). The root is always interior. DAG- and diamond-safe via the `seen`
+ * memo.
+ */
+FusedGraph build_fused_graph(tensor::TensorImpl* root);
+
+}  // namespace lmp::inductor

--- a/csrc/include/lamppp/inductor/nvrtc/nvrtc_backend.hpp
+++ b/csrc/include/lamppp/inductor/nvrtc/nvrtc_backend.hpp
@@ -1,22 +1,30 @@
 #pragma once
 
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "lamppp/inductor/nvrtc/assert.hpp"
+#include "lamppp/inductor/nvrtc/codegen.hpp"
+#include "lamppp/inductor/nvrtc/fused_graph.hpp"
+#include "lamppp/tensor/data_type.hpp"
+#include "lamppp/tensor/device_type.hpp"
+#include "lamppp/tensor/dispatch_type.hpp"
 #include "lamppp/tensor/lazy/lazy_backend.hpp"
+#include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/lazy/realize.hpp"
+#include "lamppp/tensor/storage.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
 
 namespace lmp::inductor {
 
-/**
- * @brief NVRTC-backed concrete `tensor::LazyBackend`.
- *
- * @details Realizes a lazily-captured graph by JIT-compiling fused CUDA kernels
- * via NVRTC. This is the single entry point the `tensor` module reaches through
- * the abstract `tensor::LazyBackend` seam, keeping the dependency direction
- * strictly one-way (`inductor` -> `tensor`).
- *
- * @see tensor::LazyBackend
- */
 class NVRTCInductorBackend : public tensor::LazyBackend {
  public:
   void realize(tensor::TensorImpl* impl) override;
 };
 
-}  // namespace lmp::inductor
+}

--- a/csrc/include/lamppp/tensor/data_type.hpp
+++ b/csrc/include/lamppp/tensor/data_type.hpp
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <ostream>
 
+#include "lamppp/common/assert.hpp"
+
 namespace lmp::tensor {
 
 /**
@@ -102,6 +104,28 @@ inline std::ostream& operator<<(std::ostream& os, DataType dtype) {
       break;
   }
   return os;
+}
+
+/// @brief C/CUDA type spelling for codegen (e.g. Float32 -> "float").
+inline const char* to_cname(DataType dtype) {
+  switch (dtype) {
+    case DataType::Bool:
+      return "bool";
+    case DataType::Int16:
+      return "short";
+    case DataType::Int32:
+      return "int";
+    case DataType::Int64:
+      return "long long";
+    case DataType::Float32:
+      return "float";
+    case DataType::Float64:
+      return "double";
+    default:
+      LMP_CHECK(false) << "to_cname: unknown DataType "
+                       << static_cast<int>(dtype);
+      return "";  // unreachable; silences -Wreturn-type
+  }
 }
 
 }  // namespace lmp::tensor

--- a/csrc/include/lamppp/tensor/dispatch_type.hpp
+++ b/csrc/include/lamppp/tensor/dispatch_type.hpp
@@ -13,27 +13,27 @@
 #define LMP_DISPATCH_ALL_TYPES(TYPE, ...)   \
   [&] {                                     \
     switch (TYPE) {                         \
-      case DataType::Bool: {                \
+      case lmp::tensor::DataType::Bool: {   \
         using scalar_t = bool;              \
         return __VA_ARGS__();               \
       }                                     \
-      case DataType::Int16: {               \
+      case lmp::tensor::DataType::Int16: {  \
         using scalar_t = int16_t;           \
         return __VA_ARGS__();               \
       }                                     \
-      case DataType::Int32: {               \
+      case lmp::tensor::DataType::Int32: {  \
         using scalar_t = int;               \
         return __VA_ARGS__();               \
       }                                     \
-      case DataType::Int64: {               \
+      case lmp::tensor::DataType::Int64: {  \
         using scalar_t = int64_t;           \
         return __VA_ARGS__();               \
       }                                     \
-      case DataType::Float32: {             \
+      case lmp::tensor::DataType::Float32: {\
         using scalar_t = float;             \
         return __VA_ARGS__();               \
       }                                     \
-      case DataType::Float64: {             \
+      case lmp::tensor::DataType::Float64: {\
         using scalar_t = double;            \
         return __VA_ARGS__();               \
       }                                     \

--- a/csrc/include/lamppp/tensor/lazy/functions/elementwise_binary.hpp
+++ b/csrc/include/lamppp/tensor/lazy/functions/elementwise_binary.hpp
@@ -2,18 +2,21 @@
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "lamppp/tensor/infer_meta.hpp"
 #include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/native/expand_ops.hpp"
+#include "lamppp/tensor/storage.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
 
 namespace lmp::tensor {
-class TensorImpl;
 
 struct ElementwiseBinaryFn : LazyFunction {
   using LazyFunction::LazyFunction;
-  std::shared_ptr<TensorImpl> infer_output() const override;          // defined in .cpp
-  bool is_fusible() const override;                                   // computed (same-shape => fusible; broadcast => boundary); defined in .cpp
+  std::shared_ptr<TensorImpl> infer_output() const override;
+  bool is_fusible() const override;
 };
 
-// Elementwise binary operation subclasses
 struct AddFn : ElementwiseBinaryFn {
   using ElementwiseBinaryFn::ElementwiseBinaryFn;
   void run_eager(TensorImpl& out) override;
@@ -80,4 +83,4 @@ struct LtFn : ElementwiseBinaryFn {
   std::string codegen_expr() const override { return "{0} < {1}"; }
 };
 
-}  // namespace lmp::tensor
+}

--- a/csrc/include/lamppp/tensor/lazy/lazy_backend.hpp
+++ b/csrc/include/lamppp/tensor/lazy/lazy_backend.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "lamppp/tensor/device_type.hpp"
 
 namespace lmp::tensor {
@@ -7,29 +9,16 @@ namespace lmp::tensor {
 class TensorImpl;
 class LazyFunction;
 
-/**
- * @brief Seam between the tensor module and a lazy (graph-capturing) backend.
- *
- * @details This abstract interface lets the `tensor` module hand off realization
- * of a lazily-captured graph without depending on the `inductor` module. A
- * concrete backend is registered per device via `register_backend`, and looked
- * up at runtime via `backend`. The table is keyed by `DeviceType`, mirroring the
- * dispatch pattern used elsewhere in the module.
- *
- * @see DeviceType
- */
 struct LazyBackend {
   virtual ~LazyBackend() = default;
   virtual void realize(TensorImpl*) = 0;
 };
 
-/// @brief Returns the backend registered for `dev`, or nullptr if none.
 LazyBackend* backend(DeviceType dev);
 
-/// @brief Registers `b` as the backend for `dev`, filling its slot.
 void register_backend(DeviceType dev, LazyBackend* b);
 
-}  // namespace lmp::tensor
+}
 
 #define LMP_REGISTER_LAZY_BACKEND(dev, backend_type)        \
   namespace {                                               \

--- a/csrc/include/lamppp/tensor/lazy/lazy_function.hpp
+++ b/csrc/include/lamppp/tensor/lazy/lazy_function.hpp
@@ -6,17 +6,16 @@
 namespace lmp::tensor {
 class TensorImpl;
 
-// Fusion analogue of autograd::Function: describes a pending op.
 struct LazyFunction {
-  std::vector<std::shared_ptr<TensorImpl>> inputs;   // producers, kept alive
+  std::vector<std::shared_ptr<TensorImpl>> inputs;
 
   explicit LazyFunction(std::vector<std::shared_ptr<TensorImpl>> ins)
       : inputs(std::move(ins)) {}
   virtual ~LazyFunction() = default;
 
-  virtual std::shared_ptr<TensorImpl> infer_output() const = 0; // 0-byte impl + real meta
-  virtual void run_eager(TensorImpl& out) = 0;                  // bridge to existing *_stub()
-  virtual std::string codegen_expr() const = 0;                 // Part 2 seam (per-op RHS template)
-  virtual bool is_fusible() const = 0;                          // Part 2 partition label
+  virtual std::shared_ptr<TensorImpl> infer_output() const = 0;
+  virtual void run_eager(TensorImpl& out) = 0;
+  virtual std::string codegen_expr() const = 0;
+  virtual bool is_fusible() const = 0;
 };
-}  // namespace lmp::tensor
+}

--- a/csrc/include/lamppp/tensor/lazy/realize.hpp
+++ b/csrc/include/lamppp/tensor/lazy/realize.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "lamppp/common/assert.hpp"
+#include "lamppp/tensor/lazy/lazy_backend.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
+
 namespace lmp::tensor {
 
-class TensorImpl;
-
-/// @brief Force realization of a deferred tensor via its device's backend.
 void realize(TensorImpl* impl);
 
-}  // namespace lmp::tensor
+}

--- a/csrc/include/lamppp/tensor/lazy/record.hpp
+++ b/csrc/include/lamppp/tensor/lazy/record.hpp
@@ -1,11 +1,11 @@
 #pragma once
 #include <memory>
 
-namespace lmp::tensor {
-class TensorImpl;
-class LazyFunction;
+#include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
 
-/// @brief Capture a pending op: build its deferred output impl and attach the op.
+namespace lmp::tensor {
+
 std::shared_ptr<TensorImpl> record(std::shared_ptr<LazyFunction> fn);
 
-}  // namespace lmp::tensor
+}

--- a/csrc/src/inductor/CMakeLists.txt
+++ b/csrc/src/inductor/CMakeLists.txt
@@ -7,6 +7,7 @@ if (LMP_ENABLE_CUDA)
   list(APPEND INDUCTOR_SOURCES
     nvrtc/nvrtc_backend.cpp
     nvrtc/fused_graph.cpp
+    nvrtc/codegen.cpp
   )
 endif()
 

--- a/csrc/src/inductor/CMakeLists.txt
+++ b/csrc/src/inductor/CMakeLists.txt
@@ -6,6 +6,7 @@ if (LMP_ENABLE_CUDA)
   enable_language(CUDA)
   list(APPEND INDUCTOR_SOURCES
     nvrtc/nvrtc_backend.cpp
+    nvrtc/fused_graph.cpp
   )
 endif()
 

--- a/csrc/src/inductor/CMakeLists.txt
+++ b/csrc/src/inductor/CMakeLists.txt
@@ -33,7 +33,7 @@ if (LMP_ENABLE_CUDA)
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
   )
   target_link_libraries(inductor_core
-    PUBLIC CUDA::cudart CUDA::nvrtc
+    PUBLIC CUDA::cudart CUDA::nvrtc CUDA::cuda_driver
   )
 endif()
 

--- a/csrc/src/inductor/nvrtc/codegen.cpp
+++ b/csrc/src/inductor/nvrtc/codegen.cpp
@@ -1,20 +1,8 @@
 #include "lamppp/inductor/nvrtc/codegen.hpp"
 
-#include <sstream>
-#include <string>
-#include <unordered_map>
-#include <vector>
-
-#include "lamppp/inductor/nvrtc/fused_graph.hpp"
-#include "lamppp/tensor/data_type.hpp"
-#include "lamppp/tensor/lazy/lazy_function.hpp"
-#include "lamppp/tensor/tensor_impl.hpp"
-
 namespace lmp::inductor {
 namespace {
 
-// Replace positional placeholders {0},{1},... in an op's codegen_expr template
-// with the operand strings in `args`.
 std::string substitute(const std::string& tmpl,
                        const std::vector<std::string>& args) {
   std::string out = tmpl;
@@ -28,12 +16,9 @@ std::string substitute(const std::string& tmpl,
   return out;
 }
 
-}  // namespace
+}
 
 std::string codegen_kernel(const FusedGraph& g) {
-  // ---- name every value ----
-  // boundary input at slot N -> "s{N}" (loaded from param "in{N}")
-  // interior node at order index M -> "v{M}"
   std::unordered_map<tensor::TensorImpl*, std::string> name;
   name.reserve(g.inputs.size() + g.order.size());
   for (size_t i = 0; i < g.inputs.size(); ++i)
@@ -43,7 +28,6 @@ std::string codegen_kernel(const FusedGraph& g) {
 
   std::ostringstream os;
 
-  // ---- signature: (out, in0..in{K-1}, n) ----
   os << "extern \"C\" __global__ void " << kFusedKernelName << "(\n";
   os << "    " << tensor::to_cname(g.output->type()) << "* out";
   for (size_t i = 0; i < g.inputs.size(); ++i)
@@ -51,21 +35,16 @@ std::string codegen_kernel(const FusedGraph& g) {
        << i;
   os << ",\n    size_t n) {\n";
 
-  // ---- flat index guard ----
   os << "  size_t i = blockIdx.x * blockDim.x + threadIdx.x;\n";
   os << "  if (i >= n) return;\n";
 
-  // ---- load boundary inputs (one typed load each) ----
   for (size_t i = 0; i < g.inputs.size(); ++i)
     os << "  " << tensor::to_cname(g.inputs[i]->type()) << " s" << i << " = in"
        << i << "[i];\n";
 
-  // ---- interior nodes in evaluation order ----
   for (size_t m = 0; m < g.order.size(); ++m) {
     tensor::TensorImpl* node = g.order[m];
     tensor::LazyFunction* fn = node->lazy_op().get();
-    // Per-op promotion: compute dtype == this node's output dtype (type_upcast,
-    // stamped by infer_output). Cast every operand to it before the op.
     const std::string ct = tensor::to_cname(node->type());
     std::vector<std::string> args;
     args.reserve(fn->inputs.size());
@@ -75,11 +54,10 @@ std::string codegen_kernel(const FusedGraph& g) {
        << substitute(fn->codegen_expr(), args) << ";\n";
   }
 
-  // ---- store result ----
   os << "  out[i] = " << name.at(g.output) << ";\n";
   os << "}\n";
 
   return os.str();
 }
 
-}  // namespace lmp::inductor
+}

--- a/csrc/src/inductor/nvrtc/codegen.cpp
+++ b/csrc/src/inductor/nvrtc/codegen.cpp
@@ -1,0 +1,85 @@
+#include "lamppp/inductor/nvrtc/codegen.hpp"
+
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "lamppp/inductor/nvrtc/fused_graph.hpp"
+#include "lamppp/tensor/data_type.hpp"
+#include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
+
+namespace lmp::inductor {
+namespace {
+
+// Replace positional placeholders {0},{1},... in an op's codegen_expr template
+// with the operand strings in `args`.
+std::string substitute(const std::string& tmpl,
+                       const std::vector<std::string>& args) {
+  std::string out = tmpl;
+  for (size_t j = 0; j < args.size(); ++j) {
+    const std::string ph = "{" + std::to_string(j) + "}";
+    for (size_t pos = out.find(ph); pos != std::string::npos;
+         pos = out.find(ph, pos + args[j].size())) {
+      out.replace(pos, ph.size(), args[j]);
+    }
+  }
+  return out;
+}
+
+}  // namespace
+
+std::string codegen_kernel(const FusedGraph& g) {
+  // ---- name every value ----
+  // boundary input at slot N -> "s{N}" (loaded from param "in{N}")
+  // interior node at order index M -> "v{M}"
+  std::unordered_map<tensor::TensorImpl*, std::string> name;
+  name.reserve(g.inputs.size() + g.order.size());
+  for (size_t i = 0; i < g.inputs.size(); ++i)
+    name[g.inputs[i]] = "s" + std::to_string(i);
+  for (size_t m = 0; m < g.order.size(); ++m)
+    name[g.order[m]] = "v" + std::to_string(m);
+
+  std::ostringstream os;
+
+  // ---- signature: (out, in0..in{K-1}, n) ----
+  os << "extern \"C\" __global__ void " << kFusedKernelName << "(\n";
+  os << "    " << tensor::to_cname(g.output->type()) << "* out";
+  for (size_t i = 0; i < g.inputs.size(); ++i)
+    os << ",\n    const " << tensor::to_cname(g.inputs[i]->type()) << "* in"
+       << i;
+  os << ",\n    size_t n) {\n";
+
+  // ---- flat index guard ----
+  os << "  size_t i = blockIdx.x * blockDim.x + threadIdx.x;\n";
+  os << "  if (i >= n) return;\n";
+
+  // ---- load boundary inputs (one typed load each) ----
+  for (size_t i = 0; i < g.inputs.size(); ++i)
+    os << "  " << tensor::to_cname(g.inputs[i]->type()) << " s" << i << " = in"
+       << i << "[i];\n";
+
+  // ---- interior nodes in evaluation order ----
+  for (size_t m = 0; m < g.order.size(); ++m) {
+    tensor::TensorImpl* node = g.order[m];
+    tensor::LazyFunction* fn = node->lazy_op().get();
+    // Per-op promotion: compute dtype == this node's output dtype (type_upcast,
+    // stamped by infer_output). Cast every operand to it before the op.
+    const std::string ct = tensor::to_cname(node->type());
+    std::vector<std::string> args;
+    args.reserve(fn->inputs.size());
+    for (const std::shared_ptr<tensor::TensorImpl>& in : fn->inputs)
+      args.push_back("static_cast<" + ct + ">(" + name.at(in.get()) + ")");
+    os << "  " << ct << " v" << m << " = "
+       << substitute(fn->codegen_expr(), args) << ";\n";
+  }
+
+  // ---- store result ----
+  os << "  out[i] = " << name.at(g.output) << ";\n";
+  os << "}\n";
+
+  return os.str();
+}
+
+}  // namespace lmp::inductor

--- a/csrc/src/inductor/nvrtc/fused_graph.cpp
+++ b/csrc/src/inductor/nvrtc/fused_graph.cpp
@@ -1,0 +1,43 @@
+#include "lamppp/inductor/nvrtc/fused_graph.hpp"
+
+#include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/lazy/realize.hpp"
+#include "lamppp/tensor/tensor_impl.hpp"
+
+namespace lmp::inductor {
+namespace {
+
+// Classify a NON-root node into g.
+void visit(tensor::TensorImpl* n, FusedGraph& g) {
+  if (g.seen.count(n))
+    return;  // DAG-safe + diamond-safe
+  g.seen.insert(n);
+
+  // Interior iff still deferred AND fusible; otherwise it's a boundary input.
+  if (!n->is_deferred() || !n->lazy_op()->is_fusible()) {
+    tensor::realize(n);  // force boundary input to a realized leaf
+    if (!g.slot.count(n)) {
+      g.slot[n] = g.inputs.size();
+      g.inputs.push_back(n);
+    }
+    return;
+  }
+
+  for (const std::shared_ptr<tensor::TensorImpl>& in : n->lazy_op()->inputs)
+    visit(in.get(), g);
+  g.order.push_back(n);
+}
+
+}  // namespace
+
+FusedGraph build_fused_graph(tensor::TensorImpl* root) {
+  FusedGraph g;
+  g.output = root;
+  g.seen.insert(root);  // root is the realization target -- always interior
+  for (const std::shared_ptr<tensor::TensorImpl>& in : root->lazy_op()->inputs)
+    visit(in.get(), g);
+  g.order.push_back(root);  // root evaluated last
+  return g;
+}
+
+}  // namespace lmp::inductor

--- a/csrc/src/inductor/nvrtc/fused_graph.cpp
+++ b/csrc/src/inductor/nvrtc/fused_graph.cpp
@@ -1,21 +1,15 @@
 #include "lamppp/inductor/nvrtc/fused_graph.hpp"
 
-#include "lamppp/tensor/lazy/lazy_function.hpp"
-#include "lamppp/tensor/lazy/realize.hpp"
-#include "lamppp/tensor/tensor_impl.hpp"
-
 namespace lmp::inductor {
 namespace {
 
-// Classify a NON-root node into g.
 void visit(tensor::TensorImpl* n, FusedGraph& g) {
   if (g.seen.count(n))
-    return;  // DAG-safe + diamond-safe
+    return;
   g.seen.insert(n);
 
-  // Interior iff still deferred AND fusible; otherwise it's a boundary input.
   if (!n->is_deferred() || !n->lazy_op()->is_fusible()) {
-    tensor::realize(n);  // force boundary input to a realized leaf
+    tensor::realize(n);
     if (!g.slot.count(n)) {
       g.slot[n] = g.inputs.size();
       g.inputs.push_back(n);
@@ -28,16 +22,16 @@ void visit(tensor::TensorImpl* n, FusedGraph& g) {
   g.order.push_back(n);
 }
 
-}  // namespace
+}
 
 FusedGraph build_fused_graph(tensor::TensorImpl* root) {
   FusedGraph g;
   g.output = root;
-  g.seen.insert(root);  // root is the realization target -- always interior
+  g.seen.insert(root);
   for (const std::shared_ptr<tensor::TensorImpl>& in : root->lazy_op()->inputs)
     visit(in.get(), g);
-  g.order.push_back(root);  // root evaluated last
+  g.order.push_back(root);
   return g;
 }
 
-}  // namespace lmp::inductor
+}

--- a/csrc/src/inductor/nvrtc/nvrtc_backend.cpp
+++ b/csrc/src/inductor/nvrtc/nvrtc_backend.cpp
@@ -1,48 +1,5 @@
 #include "lamppp/inductor/nvrtc/nvrtc_backend.hpp"
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <nvrtc.h>
-
-#include <mutex>
-#include <string>
-#include <vector>
-
-#include "lamppp/common/assert.hpp"
-#include "lamppp/inductor/nvrtc/codegen.hpp"
-#include "lamppp/inductor/nvrtc/fused_graph.hpp"
-#include "lamppp/tensor/device_type.hpp"
-#include "lamppp/tensor/dispatch_type.hpp"
-#include "lamppp/tensor/lazy/lazy_backend.hpp"
-#include "lamppp/tensor/lazy/lazy_function.hpp"
-#include "lamppp/tensor/lazy/realize.hpp"
-#include "lamppp/tensor/storage.hpp"
-#include "lamppp/tensor/tensor_impl.hpp"
-
-#define NVRTC_CHECK(x)                                      \
-  do {                                                      \
-    const nvrtcResult nvrtc_r = (x);                        \
-    LMP_CHECK(nvrtc_r == NVRTC_SUCCESS)                     \
-        << "NVRTC error: " << nvrtcGetErrorString(nvrtc_r); \
-  } while (0)
-
-#define CU_CHECK(x)                                                     \
-  do {                                                                  \
-    const CUresult cu_r = (x);                                          \
-    if (cu_r != CUDA_SUCCESS) {                                         \
-      const char* cu_s = nullptr;                                       \
-      cuGetErrorString(cu_r, &cu_s);                                    \
-      LMP_CHECK(false) << "CUDA driver error: " << (cu_s ? cu_s : "?"); \
-    }                                                                   \
-  } while (0)
-
-#define CUDART_CHECK(x)                                            \
-  do {                                                             \
-    const cudaError_t cudart_r = (x);                              \
-    LMP_CHECK(cudart_r == cudaSuccess)                             \
-        << "CUDA runtime error: " << cudaGetErrorString(cudart_r); \
-  } while (0)
-
 namespace lmp::inductor {
 
 namespace {
@@ -52,8 +9,6 @@ struct LoadedKernel {
   CUfunction func;
 };
 
-// Compile the generated source string to a CUBIN for THIS device's arch via
-// NVRTC, then load it into the current (cudart primary) context.
 LoadedKernel compile_and_load(const std::string& src) {
   nvrtcProgram prog;
   NVRTC_CHECK(
@@ -102,14 +57,12 @@ void launch(CUfunction f, std::vector<void*>& args, size_t n) {
   CU_CHECK(cuCtxSynchronize());
 }
 
-}  // namespace
+}
 
 void NVRTCInductorBackend::realize(tensor::TensorImpl* impl) {
   if (!impl->is_deferred())
     return;
 
-  // Non-fusible root (e.g. a broadcasting binary op): the fused kernel's flat
-  // same-shape index model doesn't apply. Realize its inputs and run it eagerly.
   if (!impl->lazy_op()->is_fusible()) {
     for (const std::shared_ptr<tensor::TensorImpl>& in :
          impl->lazy_op()->inputs)
@@ -118,28 +71,22 @@ void NVRTCInductorBackend::realize(tensor::TensorImpl* impl) {
     return;
   }
 
-  // Fusible root: partition into one group, codegen one kernel, JIT, launch.
-  FusedGraph g = build_fused_graph(impl);  // realizes all boundary inputs
+  FusedGraph g = build_fused_graph(impl);
   const std::string src = codegen_kernel(g);
 
   const size_t n = impl->numel();
   const size_t bytes = LMP_DISPATCH_ALL_TYPES(
       impl->type(), [&] { return n * sizeof(scalar_t); });
 
-  // Allocate the output FIRST: this cudart call guarantees the primary CUDA
-  // context is current on this thread before any driver-API call below.
   tensor::Storage out(bytes, tensor::DeviceType::CUDA);
 
-  if (n == 0) {  // empty tensor: nothing to launch
+  if (n == 0) {
     impl->set_realized(out);
     return;
   }
 
   LoadedKernel k = compile_and_load(src);
 
-  // Kernel args are (out, in0..in{K-1}, n). cuLaunchKernel wants a pointer to
-  // each argument *value*, so the value lvalues must stay alive (and the vector
-  // holding the input device pointers must not reallocate) until after launch.
   void* out_ptr = out.data();
   std::vector<void*> in_ptrs;
   in_ptrs.reserve(g.inputs.size());
@@ -155,26 +102,13 @@ void NVRTCInductorBackend::realize(tensor::TensorImpl* impl) {
   args.push_back(&n_arg);
 
   launch(k.func, args, n);
-  CU_CHECK(cuModuleUnload(k.module));  // no compile cache yet: unload now
+  CU_CHECK(cuModuleUnload(k.module));
 
   impl->set_realized(out);
 }
 
-// Master switch for kernel fusion. Three separate concerns, kept distinct:
-//   - LMP_ENABLE_CUDA  : whether this TU (the NVRTC backend) is compiled at all
-//   - LMP_ENABLE_FUSION: whether the lazy backend registers (this gate)
-//   - backend(device)  : the op-shim's per-op defer decision (reads registration)
-// When LMP_ENABLE_FUSION is off, no backend registers, backend(CUDA) is null,
-// and every op stays on the eager path (bit-identical to a no-inductor build).
-// NOTE(future): when fusion is off we should go further and not build/link the
-// inductor library at all, rather than building it and compiling out only the
-// registrar. Left as a follow-up.
 #ifdef LMP_ENABLE_FUSION
 LMP_REGISTER_LAZY_BACKEND(tensor::DeviceType::CUDA, NVRTCInductorBackend)
 #endif
 
-}  // namespace lmp::inductor
-
-#undef NVRTC_CHECK
-#undef CU_CHECK
-#undef CUDART_CHECK
+}

--- a/csrc/src/inductor/nvrtc/nvrtc_backend.cpp
+++ b/csrc/src/inductor/nvrtc/nvrtc_backend.cpp
@@ -1,24 +1,163 @@
 #include "lamppp/inductor/nvrtc/nvrtc_backend.hpp"
 
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include "lamppp/common/assert.hpp"
+#include "lamppp/inductor/nvrtc/codegen.hpp"
 #include "lamppp/inductor/nvrtc/fused_graph.hpp"
 #include "lamppp/tensor/device_type.hpp"
+#include "lamppp/tensor/dispatch_type.hpp"
 #include "lamppp/tensor/lazy/lazy_backend.hpp"
 #include "lamppp/tensor/lazy/lazy_function.hpp"
+#include "lamppp/tensor/lazy/realize.hpp"
+#include "lamppp/tensor/storage.hpp"
 #include "lamppp/tensor/tensor_impl.hpp"
 
+#define NVRTC_CHECK(x)                                      \
+  do {                                                      \
+    const nvrtcResult nvrtc_r = (x);                        \
+    LMP_CHECK(nvrtc_r == NVRTC_SUCCESS)                     \
+        << "NVRTC error: " << nvrtcGetErrorString(nvrtc_r); \
+  } while (0)
+
+#define CU_CHECK(x)                                                     \
+  do {                                                                  \
+    const CUresult cu_r = (x);                                          \
+    if (cu_r != CUDA_SUCCESS) {                                         \
+      const char* cu_s = nullptr;                                       \
+      cuGetErrorString(cu_r, &cu_s);                                    \
+      LMP_CHECK(false) << "CUDA driver error: " << (cu_s ? cu_s : "?"); \
+    }                                                                   \
+  } while (0)
+
+#define CUDART_CHECK(x)                                            \
+  do {                                                             \
+    const cudaError_t cudart_r = (x);                              \
+    LMP_CHECK(cudart_r == cudaSuccess)                             \
+        << "CUDA runtime error: " << cudaGetErrorString(cudart_r); \
+  } while (0)
+
 namespace lmp::inductor {
+
+namespace {
+
+struct LoadedKernel {
+  CUmodule module;
+  CUfunction func;
+};
+
+// Compile the generated source string to a CUBIN for THIS device's arch via
+// NVRTC, then load it into the current (cudart primary) context.
+LoadedKernel compile_and_load(const std::string& src) {
+  nvrtcProgram prog;
+  NVRTC_CHECK(
+      nvrtcCreateProgram(&prog, src.c_str(), "fused.cu", 0, nullptr, nullptr));
+
+  int dev = 0;
+  CUDART_CHECK(cudaGetDevice(&dev));
+  cudaDeviceProp props;
+  CUDART_CHECK(cudaGetDeviceProperties(&props, dev));
+  const std::string arch = "--gpu-architecture=sm_" +
+                           std::to_string(props.major) +
+                           std::to_string(props.minor);
+  const char* opts[] = {arch.c_str(), "--std=c++17"};
+
+  const nvrtcResult cres = nvrtcCompileProgram(prog, 2, opts);
+  if (cres != NVRTC_SUCCESS) {
+    size_t log_size = 0;
+    nvrtcGetProgramLogSize(prog, &log_size);
+    std::string log(log_size, '\0');
+    nvrtcGetProgramLog(prog, log.data());
+    LMP_CHECK(false) << "NVRTC compile failed:\n"
+                     << log << "\n--- generated source ---\n"
+                     << src;
+  }
+
+  size_t cubin_size = 0;
+  NVRTC_CHECK(nvrtcGetCUBINSize(prog, &cubin_size));
+  std::vector<char> cubin(cubin_size);
+  NVRTC_CHECK(nvrtcGetCUBIN(prog, cubin.data()));
+  NVRTC_CHECK(nvrtcDestroyProgram(&prog));
+
+  static std::once_flag init_flag;
+  std::call_once(init_flag, [] { CU_CHECK(cuInit(0)); });
+
+  LoadedKernel k;
+  CU_CHECK(cuModuleLoadData(&k.module, cubin.data()));
+  CU_CHECK(cuModuleGetFunction(&k.func, k.module, kFusedKernelName));
+  return k;
+}
+
+void launch(CUfunction f, std::vector<void*>& args, size_t n) {
+  const unsigned int block = 256;
+  const unsigned int grid = static_cast<unsigned int>((n + block - 1) / block);
+  CU_CHECK(cuLaunchKernel(f, grid, 1, 1, block, 1, 1, 0, nullptr, args.data(),
+                          nullptr));
+  CU_CHECK(cuCtxSynchronize());
+}
+
+}  // namespace
 
 void NVRTCInductorBackend::realize(tensor::TensorImpl* impl) {
   if (!impl->is_deferred())
     return;
-  FusedGraph g =
-      build_fused_graph(impl);  // forces all boundary inputs as a side effect
-  // v0: execute interior nodes eagerly in evaluation order.
-  // NOTE(next piece): replace this loop with codegen of ONE fused kernel from
-  // g.order + g.inputs/slot (via LazyFunction::codegen_expr) and a single launch.
-  for (tensor::TensorImpl* n : g.order)
-    n->lazy_op()->run_eager(*n);
+
+  // Non-fusible root (e.g. a broadcasting binary op): the fused kernel's flat
+  // same-shape index model doesn't apply. Realize its inputs and run it eagerly.
+  if (!impl->lazy_op()->is_fusible()) {
+    for (const std::shared_ptr<tensor::TensorImpl>& in :
+         impl->lazy_op()->inputs)
+      tensor::realize(in.get());
+    impl->lazy_op()->run_eager(*impl);
+    return;
+  }
+
+  // Fusible root: partition into one group, codegen one kernel, JIT, launch.
+  FusedGraph g = build_fused_graph(impl);  // realizes all boundary inputs
+  const std::string src = codegen_kernel(g);
+
+  const size_t n = impl->numel();
+  const size_t bytes = LMP_DISPATCH_ALL_TYPES(
+      impl->type(), [&] { return n * sizeof(scalar_t); });
+
+  // Allocate the output FIRST: this cudart call guarantees the primary CUDA
+  // context is current on this thread before any driver-API call below.
+  tensor::Storage out(bytes, tensor::DeviceType::CUDA);
+
+  if (n == 0) {  // empty tensor: nothing to launch
+    impl->set_realized(out);
+    return;
+  }
+
+  LoadedKernel k = compile_and_load(src);
+
+  // Kernel args are (out, in0..in{K-1}, n). cuLaunchKernel wants a pointer to
+  // each argument *value*, so the value lvalues must stay alive (and the vector
+  // holding the input device pointers must not reallocate) until after launch.
+  void* out_ptr = out.data();
+  std::vector<void*> in_ptrs;
+  in_ptrs.reserve(g.inputs.size());
+  for (tensor::TensorImpl* leaf : g.inputs)
+    in_ptrs.push_back(leaf->storage().data());
+  size_t n_arg = n;
+
+  std::vector<void*> args;
+  args.reserve(g.inputs.size() + 2);
+  args.push_back(&out_ptr);
+  for (void*& p : in_ptrs)
+    args.push_back(&p);
+  args.push_back(&n_arg);
+
+  launch(k.func, args, n);
+  CU_CHECK(cuModuleUnload(k.module));  // no compile cache yet: unload now
+
+  impl->set_realized(out);
 }
 
 // Master switch for kernel fusion. Three separate concerns, kept distinct:
@@ -35,3 +174,7 @@ LMP_REGISTER_LAZY_BACKEND(tensor::DeviceType::CUDA, NVRTCInductorBackend)
 #endif
 
 }  // namespace lmp::inductor
+
+#undef NVRTC_CHECK
+#undef CU_CHECK
+#undef CUDART_CHECK

--- a/csrc/src/inductor/nvrtc/nvrtc_backend.cpp
+++ b/csrc/src/inductor/nvrtc/nvrtc_backend.cpp
@@ -1,10 +1,10 @@
 #include "lamppp/inductor/nvrtc/nvrtc_backend.hpp"
 
 #include "lamppp/common/assert.hpp"
+#include "lamppp/inductor/nvrtc/fused_graph.hpp"
 #include "lamppp/tensor/device_type.hpp"
 #include "lamppp/tensor/lazy/lazy_backend.hpp"
 #include "lamppp/tensor/lazy/lazy_function.hpp"
-#include "lamppp/tensor/lazy/realize.hpp"
 #include "lamppp/tensor/tensor_impl.hpp"
 
 namespace lmp::inductor {
@@ -12,14 +12,26 @@ namespace lmp::inductor {
 void NVRTCInductorBackend::realize(tensor::TensorImpl* impl) {
   if (!impl->is_deferred())
     return;
-  tensor::LazyFunction* fn = impl->lazy_op().get();
-  for (const std::shared_ptr<tensor::TensorImpl>& in : fn->inputs) {
-    if (in->is_deferred())
-      tensor::realize(in.get());
-  }
-  fn->run_eager(*impl);
+  FusedGraph g =
+      build_fused_graph(impl);  // forces all boundary inputs as a side effect
+  // v0: execute interior nodes eagerly in evaluation order.
+  // NOTE(next piece): replace this loop with codegen of ONE fused kernel from
+  // g.order + g.inputs/slot (via LazyFunction::codegen_expr) and a single launch.
+  for (tensor::TensorImpl* n : g.order)
+    n->lazy_op()->run_eager(*n);
 }
 
+// Master switch for kernel fusion. Three separate concerns, kept distinct:
+//   - LMP_ENABLE_CUDA  : whether this TU (the NVRTC backend) is compiled at all
+//   - LMP_ENABLE_FUSION: whether the lazy backend registers (this gate)
+//   - backend(device)  : the op-shim's per-op defer decision (reads registration)
+// When LMP_ENABLE_FUSION is off, no backend registers, backend(CUDA) is null,
+// and every op stays on the eager path (bit-identical to a no-inductor build).
+// NOTE(future): when fusion is off we should go further and not build/link the
+// inductor library at all, rather than building it and compiling out only the
+// registrar. Left as a follow-up.
+#ifdef LMP_ENABLE_FUSION
 LMP_REGISTER_LAZY_BACKEND(tensor::DeviceType::CUDA, NVRTCInductorBackend)
+#endif
 
 }  // namespace lmp::inductor

--- a/csrc/src/tensor/lazy/functions/elementwise_binary.cpp
+++ b/csrc/src/tensor/lazy/functions/elementwise_binary.cpp
@@ -1,20 +1,15 @@
 #include "lamppp/tensor/lazy/functions/elementwise_binary.hpp"
-#include "lamppp/tensor/infer_meta.hpp"
-#include "lamppp/tensor/native/expand_ops.hpp"
-#include "lamppp/tensor/storage.hpp"
-#include "lamppp/tensor/tensor_impl.hpp"
 
 namespace lmp::tensor {
 
 std::shared_ptr<TensorImpl> ElementwiseBinaryFn::infer_output() const {
   detail::OpMeta m = detail::infer_binary(inputs[0].get(), inputs[1].get());
-  Storage empty(0, inputs[0]->device());  // 0-byte, on-device
+  Storage empty(0, inputs[0]->device());
   return std::make_shared<TensorImpl>(empty, m.shape, m.dtype);
 }
 
 bool ElementwiseBinaryFn::is_fusible() const {
-  return inputs[0]->shape() ==
-         inputs[1]->shape();  // same-shape => fusible; broadcast => boundary
+  return inputs[0]->shape() == inputs[1]->shape();
 }
 
 void AddFn::run_eager(TensorImpl& out) {
@@ -72,4 +67,4 @@ void LtFn::run_eager(TensorImpl& out) {
   out.set_realized(res.storage());
 }
 
-}  // namespace lmp::tensor
+}

--- a/csrc/src/tensor/lazy/functions/elementwise_binary.cpp
+++ b/csrc/src/tensor/lazy/functions/elementwise_binary.cpp
@@ -67,4 +67,4 @@ void LtFn::run_eager(TensorImpl& out) {
   out.set_realized(res.storage());
 }
 
-}
+}  // namespace lmp::tensor

--- a/csrc/src/tensor/lazy/lazy_backend.cpp
+++ b/csrc/src/tensor/lazy/lazy_backend.cpp
@@ -10,7 +10,7 @@ std::array<LazyBackend*, static_cast<size_t>(DeviceType::Count)>& registry() {
   return table;
 }
 
-}
+}  // namespace
 
 LazyBackend* backend(DeviceType dev) {
   return registry()[static_cast<size_t>(dev)];
@@ -20,4 +20,4 @@ void register_backend(DeviceType dev, LazyBackend* b) {
   registry()[static_cast<size_t>(dev)] = b;
 }
 
-}
+}  // namespace lmp::tensor

--- a/csrc/src/tensor/lazy/lazy_backend.cpp
+++ b/csrc/src/tensor/lazy/lazy_backend.cpp
@@ -1,19 +1,16 @@
 #include "lamppp/tensor/lazy/lazy_backend.hpp"
 
-#include <array>
-
 namespace lmp::tensor {
 
 namespace {
 
-/// @brief Meyers-singleton table holding one backend pointer per device.
 std::array<LazyBackend*, static_cast<size_t>(DeviceType::Count)>& registry() {
   static std::array<LazyBackend*, static_cast<size_t>(DeviceType::Count)>
       table{};
   return table;
 }
 
-}  // namespace
+}
 
 LazyBackend* backend(DeviceType dev) {
   return registry()[static_cast<size_t>(dev)];
@@ -23,4 +20,4 @@ void register_backend(DeviceType dev, LazyBackend* b) {
   registry()[static_cast<size_t>(dev)] = b;
 }
 
-}  // namespace lmp::tensor
+}

--- a/csrc/src/tensor/lazy/realize.cpp
+++ b/csrc/src/tensor/lazy/realize.cpp
@@ -1,9 +1,5 @@
 #include "lamppp/tensor/lazy/realize.hpp"
 
-#include "lamppp/common/assert.hpp"
-#include "lamppp/tensor/lazy/lazy_backend.hpp"
-#include "lamppp/tensor/tensor_impl.hpp"
-
 namespace lmp::tensor {
 
 void realize(TensorImpl* impl) {
@@ -14,4 +10,4 @@ void realize(TensorImpl* impl) {
   b->realize(impl);
 }
 
-}  // namespace lmp::tensor
+}

--- a/csrc/src/tensor/lazy/realize.cpp
+++ b/csrc/src/tensor/lazy/realize.cpp
@@ -10,4 +10,4 @@ void realize(TensorImpl* impl) {
   b->realize(impl);
 }
 
-}
+}  // namespace lmp::tensor

--- a/csrc/src/tensor/lazy/record.cpp
+++ b/csrc/src/tensor/lazy/record.cpp
@@ -1,15 +1,11 @@
 #include "lamppp/tensor/lazy/record.hpp"
 
-#include "lamppp/tensor/lazy/lazy_function.hpp"
-#include "lamppp/tensor/tensor_impl.hpp"
-
 namespace lmp::tensor {
 
 std::shared_ptr<TensorImpl> record(std::shared_ptr<LazyFunction> fn) {
-  std::shared_ptr<TensorImpl> out =
-      fn->infer_output();            // 0-byte impl + real meta (§3)
-  out->set_deferred(std::move(fn));  // attach pending op
+  std::shared_ptr<TensorImpl> out = fn->infer_output();
+  out->set_deferred(std::move(fn));
   return out;
 }
 
-}  // namespace lmp::tensor
+}

--- a/csrc/src/tensor/lazy/record.cpp
+++ b/csrc/src/tensor/lazy/record.cpp
@@ -8,4 +8,4 @@ std::shared_ptr<TensorImpl> record(std::shared_ptr<LazyFunction> fn) {
   return out;
 }
 
-}
+}  // namespace lmp::tensor


### PR DESCRIPTION
Restore the LMP_ENABLE_FUSION compile-time master switch, gating lazy backend registration separately from LMP_ENABLE_CUDA (build presence) and the runtime backend() registration check.

Add FusedGraph + build_fused_graph (CUDA-only, nvrtc package): partition the deferred graph into a same-shape elementwise fusion group with realized boundary inputs and a leaves-first evaluation order; the root is always interior, making the walk DAG- and diamond-safe.

Rewire NVRTCInductorBackend::realize to drive build_fused_graph, executing interior nodes eagerly per-node for now (codegen + single fused launch is the next piece).