### PR TITLE
[bindings] add nested-list ctor + scalar/reflected operators to _Vari…

### DIFF
--- a/csrc/bindings/constructor.hpp
+++ b/csrc/bindings/constructor.hpp
@@ -1,8 +1,10 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "flatten.hpp"
 #include "lamp3/tensor/core.hpp"
 #include "lamp3/autograd/core.hpp"
+#include "lamp3/common/config.hpp"
 #include "lamp3/common/macros.hpp"
 #include "lamp3/tensor/data_type.hpp"
 
@@ -13,5 +15,15 @@ inline void init_constructor(py::module_& m) {
     m.def("ones", &lmp::autograd::ones);
     m.def("rand", &lmp::autograd::rand);
     m.def("randn", &lmp::autograd::randn);
-    // TODO(root): need to figure out some workaround to bind tensor. because it's templated, maybe use std::any and type erase??
+    m.def(
+        "tensor",
+        [](const py::object& data, bool requires_grad,
+           lmp::tensor::DeviceType device, lmp::tensor::DataType dtype) {
+          auto [flat, shape] = lmp::bindings::flatten_array(data);
+          return lmp::autograd::Variable(
+              lmp::tensor::Tensor(flat, shape, device, dtype), requires_grad);
+        },
+        py::arg("data"), py::arg("requires_grad") = false,
+        py::arg("device") = lmp::DEFAULT_DEVICE,
+        py::arg("dtype") = lmp::DEFAULT_DTYPE);
 }

--- a/csrc/bindings/flatten.hpp
+++ b/csrc/bindings/flatten.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace lmp::bindings {
+
+/**
+ * @brief Recursively walk a nested python list/tuple, flattening it into a
+ * row-major @p data buffer while inferring the @p shape at each depth. Mirrors
+ * the pure-python `_flatten_array` helper in rushlite.
+ */
+inline void flatten_nested(const py::handle& obj, size_t depth,
+                           std::vector<double>& data,
+                           std::vector<size_t>& shape) {
+  if (py::isinstance<py::list>(obj) || py::isinstance<py::tuple>(obj)) {
+    auto seq = py::reinterpret_borrow<py::sequence>(obj);
+    size_t len = seq.size();
+    if (shape.size() == depth) {
+      shape.push_back(len);
+    } else if (shape[depth] != len) {
+      throw std::runtime_error("rushlite: array must be uniform");
+    }
+    for (const auto& item : seq) {
+      flatten_nested(item, depth + 1, data, shape);
+    }
+  } else {
+    data.push_back(obj.cast<double>());
+  }
+}
+
+/**
+ * @brief Flatten a nested python list/tuple into (row-major data, shape).
+ */
+inline std::pair<std::vector<double>, std::vector<size_t>> flatten_array(
+    const py::handle& obj) {
+  std::vector<double> data;
+  std::vector<size_t> shape;
+  flatten_nested(obj, 0, data, shape);
+  return {std::move(data), std::move(shape)};
+}
+
+}  // namespace lmp::bindings

--- a/csrc/bindings/variable.hpp
+++ b/csrc/bindings/variable.hpp
@@ -1,7 +1,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "flatten.hpp"
 #include "lamp3/autograd/core.hpp"
+#include "lamp3/common/config.hpp"
 #include "lamp3/common/macros.hpp"
 #include "lamp3/tensor/core.hpp"
 #include "lamp3/tensor/data_type.hpp"
@@ -13,21 +15,69 @@ using lmp::tensor::DataType;    // NOLINT(google-global-names-in-headers)
 using lmp::tensor::DeviceType;  // NOLINT(google-global-names-in-headers)
 using lmp::tensor::Tensor;      // NOLINT(google-global-names-in-headers)
 
-#define LMP_VAR_OVERLOAD(x) .def("__" #x "__", &lmp::autograd::ops::x)
 #define LMP_VAR_FUNCTION(x) .def(#x, &lmp::autograd::ops::x)
 
 inline void init_variable_overloads(py::class_<Variable>& cls) {
-  cls LMP_FOR_EACH_CARTESIAN_PRODUCT(
-      LMP_VAR_OVERLOAD,
-      (add, sub, mul, pow, matmul, neg, abs, eq, lt, le, gt, ge, ne))
-      LMP_FOR_EACH_CARTESIAN_PRODUCT(
-          LMP_VAR_FUNCTION, (to, expand_dims, squeeze, reshape, exp, log, sqrt,
-                             abs, sin, cos, tan, clamp, sum, max, min, prod))
-          .def("__truediv__", &lmp::autograd::ops::div)
-          .def("T", &lmp::autograd::ops::transpose);
+  using lmp::autograd::Variable;
+  using lmp::tensor::Scalar;
+  namespace ops = lmp::autograd::ops;
+
+  auto wrap = [](const Variable& ref, Scalar s) {
+    return Variable(Tensor(std::vector<Scalar>{s}, {1}, ref.data().device(),
+                           ref.data().type()));
+  };
+
+  cls
+      // arithmetic: register (Variable, Variable) FIRST so a Variable operand
+      // is never coerced to a scalar.
+      .def("__add__", [](const Variable& a, const Variable& b) { return a + b; })
+      .def("__add__", [](const Variable& a, Scalar s) { return a + s; })
+      .def("__radd__", [](const Variable& a, Scalar s) { return s + a; })
+      .def("__sub__", [](const Variable& a, const Variable& b) { return a - b; })
+      .def("__sub__", [](const Variable& a, Scalar s) { return a - s; })
+      .def("__rsub__", [](const Variable& a, Scalar s) { return s - a; })
+      .def("__mul__", [](const Variable& a, const Variable& b) { return a * b; })
+      .def("__mul__", [](const Variable& a, Scalar s) { return a * s; })
+      .def("__rmul__", [](const Variable& a, Scalar s) { return s * a; })
+      .def("__truediv__",
+           [](const Variable& a, const Variable& b) { return a / b; })
+      .def("__truediv__", [](const Variable& a, Scalar s) { return a / s; })
+      .def("__rtruediv__", [](const Variable& a, Scalar s) { return s / a; })
+      // pow / matmul: no free operator, dispatch to ops:: directly.
+      .def("__pow__",
+           [](const Variable& a, const Variable& b) { return ops::pow(a, b); })
+      .def("__pow__", [wrap](const Variable& a,
+                             Scalar s) { return ops::pow(a, wrap(a, s)); })
+      .def("__rpow__", [wrap](const Variable& a,
+                              Scalar s) { return ops::pow(wrap(a, s), a); })
+      .def("__matmul__", [](const Variable& a,
+                            const Variable& b) { return ops::matmul(a, b); })
+      .def("__rmatmul__", [](const Variable& a,
+                             const Variable& b) { return ops::matmul(b, a); })
+      // unary
+      .def("__neg__", [](const Variable& a) { return -a; })
+      .def("__abs__", &ops::abs)
+      // comparisons: (Variable, Variable) first, then (Variable, Scalar).
+      // Python maps `s < v` to `v.__gt__(s)`, so no reflected dunders needed.
+      .def("__eq__", [](const Variable& a, const Variable& b) { return a == b; })
+      .def("__eq__", [](const Variable& a, Scalar s) { return a == s; })
+      .def("__ne__", [](const Variable& a, const Variable& b) { return a != b; })
+      .def("__ne__", [](const Variable& a, Scalar s) { return a != s; })
+      .def("__ge__", [](const Variable& a, const Variable& b) { return a >= b; })
+      .def("__ge__", [](const Variable& a, Scalar s) { return a >= s; })
+      .def("__le__", [](const Variable& a, const Variable& b) { return a <= b; })
+      .def("__le__", [](const Variable& a, Scalar s) { return a <= s; })
+      .def("__gt__", [](const Variable& a, const Variable& b) { return a > b; })
+      .def("__gt__", [](const Variable& a, Scalar s) { return a > s; })
+      .def("__lt__", [](const Variable& a, const Variable& b) { return a < b; })
+      .def("__lt__", [](const Variable& a, Scalar s) { return a < s; })
+          LMP_FOR_EACH_CARTESIAN_PRODUCT(
+              LMP_VAR_FUNCTION,
+              (to, expand_dims, squeeze, reshape, exp, log, sqrt, abs, sin, cos,
+               tan, clamp, sum, max, min, prod))
+              .def("T", &lmp::autograd::ops::transpose);
 }
 
-#undef LMP_VAR_OVERLOAD
 #undef LMP_VAR_FUNCTION
 
 inline void init_variable(py::module_& m) {
@@ -35,6 +85,15 @@ inline void init_variable(py::module_& m) {
       py::class_<Variable>(m, "_Variable")
           .def(py::init<Tensor, bool>(), py::arg("data"),
                py::arg("requires_grad"))
+          .def(py::init([](const py::object& data, bool requires_grad,
+                           DeviceType device, DataType dtype) {
+                 auto [flat, shape] = lmp::bindings::flatten_array(data);
+                 return Variable(Tensor(flat, shape, device, dtype),
+                                 requires_grad);
+               }),
+               py::arg("data"), py::arg("requires_grad") = false,
+               py::arg("device") = lmp::DEFAULT_DEVICE,
+               py::arg("dtype") = lmp::DEFAULT_DTYPE)
           .def_property("data", &Variable::data, nullptr)
           .def_property("grad", &Variable::grad, nullptr)
           .def_property("grad_fn", &Variable::grad_fn, nullptr)


### PR DESCRIPTION
…able

Enrich the _Variable pybind binding so the Python side no longer needs a re-wrapping subclass (Section 1 of the Variable refactor):

- new flatten.hpp: shared C++ nested list/tuple -> (row-major data, shape) helper, mirroring the pure-python _flatten_array
- _Variable gains a nested-list py::init (data, requires_grad, device, dtype), keeping the internal (Tensor, bool) init
- binary/comparison dunders rebound to the scalar-aware overloads.hpp operators with (V,V) registered before (V,Scalar); adds reflected __radd__/__rsub__/__rmul__/__rtruediv__/__rpow__/__rmatmul__ so 1/(1+x), x**2, 2**x, (x<2)*x, y@x now work
- module-level tensor() factory

Purely additive: bound name stays _Variable, no Python files touched.
