### PR TITLE
Add neural network layers module with common layer implementations

### DIFF
--- a/src/rushlite/nets/__init__.py
+++ b/src/rushlite/nets/__init__.py
@@ -1,0 +1,4 @@
+from . import layers
+from .Module import Module
+
+__all__ = ["Module", "layers"]

--- a/src/rushlite/nets/layers/__init__.py
+++ b/src/rushlite/nets/layers/__init__.py
@@ -1,0 +1,15 @@
+from .activation import ReLU, Sigmoid, Softmax, Tanh
+from .container import Sequential
+from .dropout import Dropout
+from .linear import Flatten, Linear
+
+__all__ = [
+    "ReLU",
+    "Sigmoid",
+    "Softmax",
+    "Tanh",
+    "Sequential",
+    "Dropout",
+    "Flatten",
+    "Linear",
+]

--- a/src/rushlite/nets/layers/activation.py
+++ b/src/rushlite/nets/layers/activation.py
@@ -1,0 +1,40 @@
+import sys
+
+from rushlite import _C
+from rushlite._C import Variable
+
+from ..Module import Module
+
+
+class ReLU(Module):
+    def forward(self, x: Variable) -> Variable:
+        return _C.clamp(x, 0, sys.float_info.max)
+
+
+class Sigmoid(Module):
+    def forward(self, x: Variable) -> Variable:
+        return 1 / (1 + _C.exp(-x))
+
+
+class Tanh(Module):
+    def forward(self, x: Variable) -> Variable:
+        exp_x = _C.exp(x)
+        nexp_x = _C.exp(-x)
+        return (exp_x - nexp_x) / (exp_x + nexp_x)
+
+
+class Softmax(Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x: Variable) -> Variable:
+        dim_idx = x.ndim + self.dim if self.dim < 0 else self.dim
+        if not 0 <= dim_idx < x.ndim:
+            raise ValueError("Dim not in bounds")
+
+        max_vals = _C.max(x, dim_idx)
+        x_shifted = x - max_vals
+
+        exp_x = _C.exp(x_shifted)
+        return exp_x / _C.sum(exp_x, dim_idx)

--- a/src/rushlite/nets/layers/container.py
+++ b/src/rushlite/nets/layers/container.py
@@ -1,0 +1,19 @@
+from typing import Any, Sequence as PySequence
+
+from ..Module import Module
+
+
+class Sequential(Module):
+    def __init__(self, layers: "PySequence[Module]") -> None:
+        super().__init__()
+        self.layers = list(layers)
+        for i, layer in enumerate(self.layers):
+            self._params_dict[str(i)] = layer
+
+    def forward(self, *args: Any) -> Any:
+        if not self.layers:
+            raise ValueError("Must have at least one layer")
+        out = self.layers[0](*args)
+        for layer in self.layers[1:]:
+            out = layer(out)
+        return out

--- a/src/rushlite/nets/layers/dropout.py
+++ b/src/rushlite/nets/layers/dropout.py
@@ -1,0 +1,14 @@
+from rushlite import _C
+from rushlite._C import Variable
+
+from ..Module import Module
+
+
+class Dropout(Module):
+    def __init__(self, p: float) -> None:
+        super().__init__()
+        self.p = p
+
+    def forward(self, x: Variable) -> Variable:
+        mask = _C.rand(x.shape)
+        return (mask < self.p) * x

--- a/src/rushlite/nets/layers/linear.py
+++ b/src/rushlite/nets/layers/linear.py
@@ -1,0 +1,61 @@
+from rushlite import _C
+from rushlite._C import Variable
+
+from ..Module import Module
+
+
+class Linear(Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        device: "_C.device | None" = None,
+        dtype: "_C.dtype | None" = None,
+    ) -> None:
+        super().__init__()
+        # None falls through to the C++ DEFAULT_DEVICE/DEFAULT_DTYPE
+        kwargs = {}
+        if device is not None:
+            kwargs["device"] = device
+        if dtype is not None:
+            kwargs["dtype"] = dtype
+
+        self.requires_bias = bias
+        self.weights = _C.randn(
+            0, 1, [in_features, out_features], requires_grad=True, **kwargs
+        )
+        if bias:
+            self.bias = _C.randn(0, 1, [out_features], requires_grad=True, **kwargs)
+
+    def forward(self, x: Variable) -> Variable:
+        if not self.requires_bias:  # (batch x in) x (in x out)
+            return _C.matmul(x, self.weights)
+        return _C.matmul(x, self.weights) + self.bias
+
+
+class Flatten(Module):
+    def __init__(self, start_dim: int = 1, end_dim: int = -1) -> None:
+        super().__init__()
+        if start_dim < 0:
+            raise ValueError("Start dim must be non-negative")
+        self.start_dim = start_dim
+        self.end_dim = end_dim
+
+    def forward(self, x: Variable) -> Variable:
+        end_dim_idx = x.ndim + self.end_dim if self.end_dim < 0 else self.end_dim
+        if not self.start_dim < end_dim_idx:
+            raise ValueError("Start and end dims not valid")
+
+        flattened_dims = 1
+        new_shape = []
+
+        for i in range(x.ndim):
+            if i < self.start_dim or i > end_dim_idx:
+                new_shape.append(x.shape[i])
+                continue
+            flattened_dims *= x.shape[i]
+            if i == end_dim_idx:
+                new_shape.append(flattened_dims)
+
+        return _C.reshape(x, new_shape)


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive layers module for the rushlite neural network library, providing essential building blocks for constructing neural networks.

## Key Changes
- **Linear layer** (`linear.py`): Implements fully connected layers with optional bias, supporting configurable device and dtype
- **Activation functions** (`activation.py`): Adds ReLU, Sigmoid, Tanh, and Softmax activation layers with proper numerical stability (e.g., max-shifting in Softmax)
- **Container layer** (`container.py`): Implements Sequential module for composing layers into a pipeline
- **Dropout layer** (`dropout.py`): Adds dropout regularization with configurable dropout probability
- **Flatten layer** (`linear.py`): Implements tensor flattening with configurable start and end dimensions
- **Module exports** (`__init__.py`): Provides clean public API for the layers module

## Notable Implementation Details
- All layers inherit from the base `Module` class and implement the `forward` method
- Linear layer uses `_C.randn` with shape `[0, 1, ...]` for weight initialization (likely for broadcasting)
- Softmax includes numerical stability by subtracting max values before exponentiation
- Flatten layer properly handles negative dimension indices and validates dimension ranges
- Sequential container stores layers in `_params_dict` for proper parameter tracking during training

https://claude.ai/code/session_01WfsNTLMSPxZWd4NZuypsGz