### PR TITLE
feat: add no_grad context manager and rework Module to a params-only store

### DIFF
--- a/csrc/bindings/core.cpp
+++ b/csrc/bindings/core.cpp
@@ -10,6 +10,7 @@
 #include "variable.hpp"
 #include "constructor.hpp"
 #include "capture_mode.hpp"
+#include "grad_mode.hpp"
 #include "functions/binary.hpp"
 #include "functions/unary.hpp"
 #include "functions/matrix.hpp"
@@ -23,6 +24,7 @@ PYBIND11_MODULE(_C, m) {
     init_variable(m);
     init_constructor(m);
     init_capture_mode(m);
+    init_grad_mode(m);
 
     init_binary(m);
     init_unary(m);

--- a/csrc/bindings/grad_mode.hpp
+++ b/csrc/bindings/grad_mode.hpp
@@ -1,0 +1,11 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "lamp3/autograd/grad_mode.hpp"
+
+namespace py = pybind11;
+
+inline void init_grad_mode(py::module_& m) {
+    m.def("set_grad_enabled", &lmp::autograd::set_grad_enabled);
+    m.def("is_grad_enabled", &lmp::autograd::is_grad_enabled);
+}

--- a/csrc/include/lamp3/autograd/core.hpp
+++ b/csrc/include/lamp3/autograd/core.hpp
@@ -3,6 +3,7 @@
 #include "lamp3/autograd/utils/constructor.hpp"
 #include "lamp3/autograd/forward_function.hpp"
 #include "lamp3/autograd/function.hpp"
+#include "lamp3/autograd/grad_mode.hpp"
 #include "lamp3/autograd/functions/expand_ops.hpp"
 #include "lamp3/autograd/functions/matrix_ops.hpp"
 #include "lamp3/autograd/functions/overloads.hpp"

--- a/csrc/include/lamp3/autograd/forward_function.hpp
+++ b/csrc/include/lamp3/autograd/forward_function.hpp
@@ -2,6 +2,7 @@
 
 #include <numeric>
 #include "function.hpp"
+#include "grad_mode.hpp"
 #include "variable.hpp"
 
 namespace lmp::autograd {
@@ -24,7 +25,7 @@ struct ForwardFunction : public Function {
 
   template <typename... Args>
   variable_list apply(const variable_list& inputs, Args&&... args) {
-    bool requires_grad_ = requires_grad(inputs);
+    bool requires_grad_ = is_grad_enabled() && requires_grad(inputs);
     Variable result =
         Variable(static_cast<Derived*>(this)->execute(inputs), requires_grad_);
     if (requires_grad_) {

--- a/csrc/include/lamp3/autograd/grad_mode.hpp
+++ b/csrc/include/lamp3/autograd/grad_mode.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace lmp::autograd {
+
+class GradModeGuard {
+public:
+    explicit GradModeGuard(bool grad_enabled);
+    ~GradModeGuard();
+
+private:
+bool prev;
+};
+
+bool is_grad_enabled();
+
+void set_grad_enabled(bool enable);
+
+}  // namespace lmp::autograd

--- a/csrc/src/autograd/CMakeLists.txt
+++ b/csrc/src/autograd/CMakeLists.txt
@@ -3,6 +3,7 @@ project(autograd_lib LANGUAGES CXX)
 set(AUTOGRAD_SOURCES
   utils/constructor.cpp
   variable.cpp
+  grad_mode.cpp
   utils/grad_utils.cpp
   functions/matrix_ops.cpp
   functions/unary_ops.cpp

--- a/csrc/src/autograd/grad_mode.cpp
+++ b/csrc/src/autograd/grad_mode.cpp
@@ -1,0 +1,18 @@
+#include "lamp3/autograd/grad_mode.hpp"
+
+namespace lmp::autograd {
+
+bool thread_local grad_enabled = true;
+
+GradModeGuard::GradModeGuard(bool grad_enabled) {
+  prev = is_grad_enabled();
+  set_grad_enabled(grad_enabled);
+}
+
+GradModeGuard::~GradModeGuard() { set_grad_enabled(prev); }
+
+bool is_grad_enabled() { return grad_enabled; }
+
+void set_grad_enabled(bool enable) { grad_enabled = enable; }
+
+}  // namespace lmp::autograd

--- a/csrc/tests/autograd_tests.cpp
+++ b/csrc/tests/autograd_tests.cpp
@@ -4,13 +4,18 @@
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
+#include <stdexcept>
 #include <vector>
 
 #include "lamp3/autograd/core.hpp"
 #include "lamp3/autograd/functions/view_ops.hpp"
+#include "lamp3/autograd/grad_mode.hpp"
 #include "lamp3/tensor/core.hpp"
 #include "lamp3/tensor/device_type.hpp"
 
+using lmp::autograd::GradModeGuard;
+using lmp::autograd::is_grad_enabled;
+using lmp::autograd::set_grad_enabled;
 using lmp::autograd::Variable;
 using lmp::tensor::DataType;
 using lmp::tensor::DeviceType;
@@ -419,6 +424,60 @@ TEST_P(VariableOpTest, ZeroGradTest) {
               ::testing::Pointwise(::testing::FloatNear(kEps),
                                    {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}))
       << "Variable 'b' gradients should be zero after zero_grad";
+}
+
+TEST_P(VariableOpTest, NoGradDisablesRecordingTest) {
+  EXPECT_TRUE(is_grad_enabled());
+  {
+    GradModeGuard guard(false);
+    EXPECT_FALSE(is_grad_enabled());
+
+    Variable res = a_ + b_;
+    EXPECT_FALSE(res.requires_grad())
+        << "Result should not require grad when grad mode is disabled";
+    EXPECT_TRUE(res.grad_fn().expired())
+        << "No backward node should be recorded when grad mode is disabled";
+  }
+  EXPECT_TRUE(is_grad_enabled())
+      << "Guard should restore previous grad mode on scope exit";
+}
+
+TEST_P(VariableOpTest, NoGradLeafConstructionUnaffectedTest) {
+  GradModeGuard guard(false);
+  Variable leaf = Variable(a_data_, true);
+  EXPECT_TRUE(leaf.requires_grad())
+      << "Explicit requires_grad on leaf construction must be honored inside "
+         "no_grad";
+}
+
+TEST_P(VariableOpTest, NoGradGuardRestoresOnExceptionTest) {
+  set_grad_enabled(true);
+  try {
+    GradModeGuard guard(false);
+    EXPECT_FALSE(is_grad_enabled());
+    throw std::runtime_error("boom");
+  } catch (const std::runtime_error&) {
+    // expected
+  }
+  EXPECT_TRUE(is_grad_enabled())
+      << "Guard destructor must restore grad mode even when unwound by an "
+         "exception";
+}
+
+TEST_P(VariableOpTest, BackwardInsideNoGradTest) {
+  Variable res = a_ + b_;
+  {
+    GradModeGuard guard(false);
+    res.backward();
+  }
+  EXPECT_THAT(getTenData(a_.grad()),
+              ::testing::Pointwise(::testing::FloatNear(kEps),
+                                   {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}))
+      << "backward() on a pre-built graph must still work inside no_grad";
+  EXPECT_THAT(getTenData(b_.grad()),
+              ::testing::Pointwise(::testing::FloatNear(kEps),
+                                   {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}))
+      << "backward() on a pre-built graph must still work inside no_grad";
 }
 
 namespace {

--- a/src/rushlite/__init__.py
+++ b/src/rushlite/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from rushlite._C import *  # noqa: F403
 from rushlite._C import Variable
 from .capture_mode import capture_on, capture
+from .grad_mode import no_grad
 from .nets.Module import Module
 
-__all__ = ["Variable", "Module", "capture_on", "capture"]
+__all__ = ["Variable", "Module", "capture_on", "capture", "no_grad"]

--- a/src/rushlite/grad_mode.py
+++ b/src/rushlite/grad_mode.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager
+from rushlite._C import set_grad_enabled, is_grad_enabled
+
+
+@contextmanager
+def no_grad():
+    prev = is_grad_enabled()
+    try:
+        set_grad_enabled(False)
+        yield
+    finally:
+        set_grad_enabled(prev)

--- a/src/rushlite/nets/Module.py
+++ b/src/rushlite/nets/Module.py
@@ -1,7 +1,47 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generator
+from typing import Any, Generator, Iterator
 
 from rushlite._C import Variable
+
+
+class _ParamsView:
+    def __init__(self, module: "Module") -> None:
+        self._module = module
+
+    @staticmethod
+    def _split(path: str) -> tuple[list[str], str]:
+        parts = path.split(".")
+        return parts[:-1], parts[-1]
+
+    def _resolve_owner(self, path: str, create: bool = False) -> tuple["Module", str]:
+        parents, leaf = self._split(path)
+        owner = self._module
+        for part in parents:
+            val = owner._params_dict.get(part)
+            if not isinstance(val, Module):
+                raise KeyError(f"No submodule '{part}' along path '{path}'")
+            owner = val
+        return owner, leaf
+
+    def __getitem__(self, path: str) -> Variable:
+        owner, leaf = self._resolve_owner(path)
+        val = owner._params_dict.get(leaf)
+        if not isinstance(val, Variable):
+            raise KeyError(f"No parameter named '{path}'")
+        return val
+
+    def __setitem__(self, path: str, value: Variable) -> None:
+        owner, leaf = self._resolve_owner(path)
+        if not value.requires_grad:
+            value = Variable(value.data, requires_grad=True)
+        owner._params_dict[leaf] = value
+
+    def __iter__(self) -> Iterator[str]:
+        for name, _ in self._module.named_parameters():
+            yield name
+
+    def keys(self) -> Iterator[str]:
+        return iter(self)
 
 
 class Module(ABC):
@@ -13,9 +53,46 @@ class Module(ABC):
         pass
 
     def __setattr__(self, name: str, value: Any, /) -> None:
-        if isinstance(value, Module) or isinstance(value, Variable):
-            self._params_dict[name] = value
+        if name == "_params_dict":
+            super().__setattr__(name, value)
+            return
+
+        params_dict = self.__dict__.get("_params_dict")
+        if params_dict is None:
+            raise AttributeError(
+                "call super().__init__() before assigning/accessing parameters"
+            )
+
+        if isinstance(value, (Module, Variable)):
+            params_dict[name] = value
+            return
+
+        params_dict.pop(name, None)
         super().__setattr__(name, value)
+
+    def __getattr__(self, name: str) -> Any:
+        params_dict = self.__dict__.get("_params_dict")
+        if params_dict is None:
+            raise AttributeError(
+                "call super().__init__() before assigning/accessing parameters"
+            )
+        try:
+            return params_dict[name]
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            ) from None
+
+    def __delattr__(self, name: str) -> None:
+        params_dict = self.__dict__.get("_params_dict")
+        if params_dict is not None and name in params_dict:
+            del params_dict[name]
+            return
+        super().__delattr__(name)
+
+    @property
+    def params(self) -> _ParamsView:
+        return _ParamsView(self)
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         return self.forward(*args, **kwds)


### PR DESCRIPTION
## Summary

- Adds a `no_grad` context manager (and decorator, via `ContextDecorator`) mirroring the existing `capture_mode` thread-local/RAII-guard stack: `csrc/include/lamp3/autograd/grad_mode.hpp` + `csrc/src/autograd/grad_mode.cpp` for the thread-local flag and `GradModeGuard`, a pybind11 binding in `csrc/bindings/grad_mode.hpp`, and `src/rushlite/grad_mode.py` exported as `rsl.no_grad`.
- The entire gating logic is one line in `ForwardFunction::apply`: `is_grad_enabled() && requires_grad(inputs)`. Leaf construction (`Variable(x, requires_grad=True)`) is unaffected inside `no_grad`, matching PyTorch. Backward passes are also unaffected, since `*Backward` functions derive from `Function` directly and never route through `ForwardFunction::apply` — verified with a dedicated test.
- Reworks `Module` (`src/rushlite/nets/Module.py`) so `_params_dict` is the single source of truth for parameters instead of being duplicated as instance attributes. `__setattr__`/`__getattr__`/`__delattr__` route `Variable`/`Module` values through the dict (guarding pre-`__init__` access), and a new `params` property resolves dotted paths across submodules for functional parameter updates (`model.params[name] = ...`), promoting the assigned value to a grad-requiring leaf when needed. This is what makes `with rsl.no_grad(): model.params[name] = p - lr * rsl.Variable(p.grad)` actually reach `forward()`.

## Test plan

- [x] New C++ tests in `csrc/tests/autograd_tests.cpp`: `NoGradDisablesRecordingTest`, `NoGradLeafConstructionUnaffectedTest`, `NoGradGuardRestoresOnExceptionTest`, `BackwardInsideNoGradTest` — all pass, full `autograd_tests` suite (22 tests) green.
- [x] Manually verified end-to-end in Python: nested `Sequential([Linear, Linear])` training loop with `with rsl.no_grad(): model.params[name] = p - lr * rsl.Variable(p.grad)` correctly updates weights across steps and reaches subsequent `forward()` calls.
- [x] Verified `hasattr`/`vars()`/pre-`__init__` attribute-access guard behavior for the reworked `Module` storage.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01KBxbNCjpdaAcpGtntnCbeB