### PR TITLE
[bug] benchmark harness updates

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,12 +1,22 @@
 ## Benchmarks:
 
-Across the board, my library consistently faster than Pytorch for the CUDA implementations, and many orders of magnitudes slower for the CPU implementation (but I mean who uses CPU for machine learning anyway :p). Would like to note that these benchmarks just look at operators, and Pytorch also has optimizations when dealing with groups of operators, which was not benchmarked here (UPDATE: kernel fusion has been implemented, will add benchmarks in a future PR). 
+Across the board, my library consistently faster than Pytorch for the CUDA implementations, and many orders of magnitudes slower for the CPU implementation (but I mean who uses CPU for machine learning anyway :p). Would like to note that these benchmarks just look at operators, and Pytorch also has optimizations when dealing with groups of operators, which was not benchmarked here (UPDATE: kernel fusion has been implemented, will add benchmarks in a future PR).
 
-Commands run: 
+### Measurement protocol
+
+Both harnesses measure synchronized end-to-end per-op time with the same protocol, so the CSVs are directly comparable:
+
+- Inputs (and, for backward, the graph) are built once, outside the timed region.
+- Each timed iteration runs a batch of ops followed by one device synchronize, all inside the timed region; the reported time is elapsed / batch size. Without the in-loop synchronize, CUDA benchmarks would only time host-side kernel enqueue.
+- Backward is called repeatedly on the retained graph with no reduction on either side: Lamp3's `backward()` seeds `ones_like(out)` internally, and the PyTorch side matches it with `out.backward(torch.ones_like(out), retain_graph=True)`. Gradients accumulate across calls (no zero_grad). A reduction is deliberately not inserted (operator_benchmark's `mean().backward()` is a workaround for PyTorch requiring a scalar); it would dominate the measurement with the reduction's backward rather than the op's own.
+
+Note: results generated before this protocol (the images below) did not synchronize inside the timed region on the Lamp3 side and overstate the CUDA gap. They should be regenerated.
+
+Commands run:
 
 ```bash
-build/benchmarks/reg_bench_long --benchmark_format=csv --benchmark_time_unit=us --benchmark_min_time=0.01s > bench_lmp.csv
-python -m pt.all_tests --output-csv bench_torch.2.csv --min-time-per-test 10
+build/benchmarks/reg_bench_long --benchmark_format=csv --benchmark_time_unit=us > bench_lmp.csv
+python -m pt.all_tests --output-csv bench_torch.csv --min-time-per-test 10
 ```
 
 - GPU: RunPod, NVIDIA RTX 4000 Ada
@@ -17,4 +27,3 @@ Docker container: https://github.com/rushlite/rushlite_image
 ![image](https://github.com/user-attachments/assets/a88e19b3-103e-4e74-ae3e-444d0a35e059)
 ![image](https://github.com/user-attachments/assets/38618e8a-2aba-449b-a0f7-6a6fe63c32f3)
 ![image](https://github.com/user-attachments/assets/625b5ac0-6226-43bb-bb3b-02a3ee6b03ac)
-

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,18 +1,8 @@
 ## Benchmarks:
 
-Across the board, my library consistently faster than Pytorch for the CUDA implementations, and many orders of magnitudes slower for the CPU implementation (but I mean who uses CPU for machine learning anyway :p). Would like to note that these benchmarks just look at operators, and Pytorch also has optimizations when dealing with groups of operators, which was not benchmarked here (UPDATE: kernel fusion has been implemented, will add benchmarks in a future PR).
+Across the board, my library consistently faster than Pytorch for the CUDA implementations, and many orders of magnitudes slower for the CPU implementation (but I mean who uses CPU for machine learning anyway :p). Would like to note that these benchmarks just look at operators, and Pytorch also has optimizations when dealing with groups of operators, which was not benchmarked here (UPDATE: kernel fusion has been implemented, will add benchmarks in a future PR). 
 
-### Measurement protocol
-
-Both harnesses measure synchronized end-to-end per-op time with the same protocol, so the CSVs are directly comparable:
-
-- Inputs (and, for backward, the graph) are built once, outside the timed region.
-- Each timed iteration runs a batch of ops followed by one device synchronize, all inside the timed region; the reported time is elapsed / batch size. Without the in-loop synchronize, CUDA benchmarks would only time host-side kernel enqueue.
-- Backward is called repeatedly on the retained graph with no reduction on either side: Lamp3's `backward()` seeds `ones_like(out)` internally, and the PyTorch side matches it with `out.backward(torch.ones_like(out), retain_graph=True)`. Gradients accumulate across calls (no zero_grad). A reduction is deliberately not inserted (operator_benchmark's `mean().backward()` is a workaround for PyTorch requiring a scalar); it would dominate the measurement with the reduction's backward rather than the op's own.
-
-Note: results generated before this protocol (the images below) did not synchronize inside the timed region on the Lamp3 side and overstate the CUDA gap. They should be regenerated.
-
-Commands run:
+Commands run: 
 
 ```bash
 build/benchmarks/reg_bench_long --benchmark_format=csv --benchmark_time_unit=us > bench_lmp.csv
@@ -27,3 +17,4 @@ Docker container: https://github.com/rushlite/rushlite_image
 ![image](https://github.com/user-attachments/assets/a88e19b3-103e-4e74-ae3e-444d0a35e059)
 ![image](https://github.com/user-attachments/assets/38618e8a-2aba-449b-a0f7-6a6fe63c32f3)
 ![image](https://github.com/user-attachments/assets/625b5ac0-6226-43bb-bb3b-02a3ee6b03ac)
+

--- a/benchmarks/lamp3/op_defs.hpp
+++ b/benchmarks/lamp3/op_defs.hpp
@@ -78,12 +78,12 @@ class BinaryOperatorBase : public OperatorBase {
                                    config.device, config.dtype)};
     };
 
-    std::string bench_name =
-        name() + "_" + to_string(config.shapes) + "_" +
-        to_string(config.dtype) + "_" +
-        (config.device == lmp::tensor::DeviceType::CUDA ? "CUDA" : "CPU");
-    register_forward<2>(bench_name, op_fn, init_fn);
-    register_backward<2>(bench_name, op_fn, init_fn);
+    bool is_cuda = config.device == lmp::tensor::DeviceType::CUDA;
+    std::string bench_name = name() + "_" + to_string(config.shapes) + "_" +
+                             to_string(config.dtype) + "_" +
+                             (is_cuda ? "CUDA" : "CPU");
+    register_forward<2>(bench_name, op_fn, init_fn, is_cuda);
+    register_backward<2>(bench_name, op_fn, init_fn, is_cuda);
   }
 
  protected:
@@ -103,12 +103,12 @@ class UnaryOperatorBase : public OperatorBase {
                                   config.device, config.dtype)};
     };
 
-    std::string bench_name =
-        name() + "_" + to_string(config.shapes) + "_" +
-        to_string(config.dtype) + "_" +
-        (config.device == lmp::tensor::DeviceType::CUDA ? "CUDA" : "CPU");
-    register_forward<1>(bench_name, op_fn, init_fn);
-    register_backward<1>(bench_name, op_fn, init_fn);
+    bool is_cuda = config.device == lmp::tensor::DeviceType::CUDA;
+    std::string bench_name = name() + "_" + to_string(config.shapes) + "_" +
+                             to_string(config.dtype) + "_" +
+                             (is_cuda ? "CUDA" : "CPU");
+    register_forward<1>(bench_name, op_fn, init_fn, is_cuda);
+    register_backward<1>(bench_name, op_fn, init_fn, is_cuda);
   }
 
  protected:
@@ -134,12 +134,13 @@ class ReductOperatorBase : public OperatorBase {
         return apply_operation(inputs[0], axis);
       };
 
+      bool is_cuda = config.device == lmp::tensor::DeviceType::CUDA;
       std::string bench_name =
           name() + "_axis" + std::to_string(axis) + "_" +
           to_string(config.shapes) + "_" + to_string(config.dtype) + "_" +
-          (config.device == lmp::tensor::DeviceType::CUDA ? "CUDA" : "CPU");
-      register_forward<1>(bench_name, op_fn, init_fn);
-      register_backward<1>(bench_name, op_fn, init_fn);
+          (is_cuda ? "CUDA" : "CPU");
+      register_forward<1>(bench_name, op_fn, init_fn, is_cuda);
+      register_backward<1>(bench_name, op_fn, init_fn, is_cuda);
     }
   }
 

--- a/benchmarks/lamp3/op_defs.hpp
+++ b/benchmarks/lamp3/op_defs.hpp
@@ -135,10 +135,10 @@ class ReductOperatorBase : public OperatorBase {
       };
 
       bool is_cuda = config.device == lmp::tensor::DeviceType::CUDA;
-      std::string bench_name =
-          name() + "_axis" + std::to_string(axis) + "_" +
-          to_string(config.shapes) + "_" + to_string(config.dtype) + "_" +
-          (is_cuda ? "CUDA" : "CPU");
+      std::string bench_name = name() + "_axis" + std::to_string(axis) + "_" +
+                               to_string(config.shapes) + "_" +
+                               to_string(config.dtype) + "_" +
+                               (is_cuda ? "CUDA" : "CPU");
       register_forward<1>(bench_name, op_fn, init_fn, is_cuda);
       register_backward<1>(bench_name, op_fn, init_fn, is_cuda);
     }

--- a/benchmarks/lamp3/reg_defs.hpp
+++ b/benchmarks/lamp3/reg_defs.hpp
@@ -3,6 +3,7 @@
 #include <benchmark/benchmark.h>
 
 #include <array>
+#include <chrono>
 #include <functional>
 #include <string>
 
@@ -12,6 +13,25 @@
 #include <cuda_runtime_api.h>
 #endif
 
+// Benchmark harness.
+//
+// Measures synchronized end-to-end per-op time using the same protocol as
+// PyTorch's operator_benchmark framework (benchmarks/torch/all_tests.py), so
+// the two CSVs are directly comparable:
+//
+//  - Inputs (and, for backward, the graph) are built once, outside the timed
+//    region.
+//  - Each timed iteration runs a batch of kOpsPerRound ops followed by ONE
+//    device synchronize, all inside the timed region; the reported time is
+//    elapsed / kOpsPerRound. Batching amortizes the fixed sync latency the
+//    same way operator_benchmark's inner loop does. Without the in-loop sync,
+//    CUDA benchmarks would only time host-side kernel enqueue and return
+//    before the GPU has done the work.
+//  - Backward is called repeatedly on the retained graph with no reduction:
+//    Lamp3's backward() seeds ones_like(out) internally, so the PyTorch side
+//    must match with `out.backward(torch.ones_like(out), retain_graph=True)`.
+//    Gradients accumulate across calls on both sides (no zero_grad).
+
 template <size_t N>
 using OperatorFunction = std::function<lmp::autograd::Variable(
     const std::array<lmp::autograd::Variable, N>&)>;
@@ -19,53 +39,69 @@ template <size_t N>
 using InitializerFunction =
     std::function<std::array<lmp::autograd::Variable, N>(bool)>;
 
-const size_t kIterations = 10;
-const float kWarmUpTime = 1;
+const size_t kOpsPerRound = 100;
+// Accumulated manual time per benchmark. The manual time is per-op (round
+// elapsed / kOpsPerRound), so each benchmark's wall time is roughly
+// kMinTimeSeconds * kOpsPerRound.
+const double kMinTimeSeconds = 0.005;
+
+inline void device_sync(bool is_cuda) {
+#ifdef LMP_ENABLE_CUDA
+  if (is_cuda) {
+    cudaDeviceSynchronize();
+  }
+#else
+  (void)is_cuda;
+#endif
+}
+
+inline void run_timed_loop(benchmark::State& state,
+                           const std::function<void()>& run_op, bool is_cuda) {
+  for (auto _ : state) {
+    auto start = std::chrono::steady_clock::now();
+    for (size_t i = 0; i < kOpsPerRound; ++i) {
+      run_op();
+    }
+    device_sync(is_cuda);
+    auto end = std::chrono::steady_clock::now();
+    state.SetIterationTime(std::chrono::duration<double>(end - start).count() /
+                           static_cast<double>(kOpsPerRound));
+  }
+}
 
 template <size_t N>
 void register_forward(const std::string& name, const OperatorFunction<N>& op_fn,
-                      const InitializerFunction<N>& init_fn) {
+                      const InitializerFunction<N>& init_fn, bool is_cuda) {
   benchmark::RegisterBenchmark(
       name + "Forward",
-      [op_fn, init_fn](benchmark::State& state) {
-        for (auto _ : state) {
-          state.PauseTiming();
-          std::array<lmp::autograd::Variable, N> inputs = init_fn(false);
-          state.ResumeTiming();
+      [op_fn, init_fn, is_cuda](benchmark::State& state) {
+        std::array<lmp::autograd::Variable, N> inputs = init_fn(false);
+        auto run_op = [op_fn, inputs]() {
           lmp::autograd::Variable result = op_fn(inputs);
           benchmark::DoNotOptimize(result);
-        }
+        };
+        run_op();  // warm-up: prime allocations and caches
+        device_sync(is_cuda);
+        run_timed_loop(state, run_op, is_cuda);
       })
-      ->MinWarmUpTime(kWarmUpTime)
-      ->Teardown([](const benchmark::State& state) {
-#ifdef LMP_ENABLE_CUDA
-        cudaStreamSynchronize(0);
-        cudaDeviceSynchronize();
-#endif
-      });
+      ->UseManualTime()
+      ->MinTime(kMinTimeSeconds);
 }
 
 template <size_t N>
 void register_backward(const std::string& name,
                        const OperatorFunction<N>& op_fn,
-                       const InitializerFunction<N>& init_fn) {
+                       const InitializerFunction<N>& init_fn, bool is_cuda) {
   benchmark::RegisterBenchmark(
       name + "Backward",
-      [op_fn, init_fn](benchmark::State& state) {
-        for (auto _ : state) {
-          state.PauseTiming();
-          std::array<lmp::autograd::Variable, N> inputs = init_fn(true);
-          lmp::autograd::Variable result = op_fn(inputs);
-          state.ResumeTiming();
-          result.backward();
-          benchmark::DoNotOptimize(result);
-        }
+      [op_fn, init_fn, is_cuda](benchmark::State& state) {
+        std::array<lmp::autograd::Variable, N> inputs = init_fn(true);
+        lmp::autograd::Variable out = op_fn(inputs);
+        auto run_op = [out]() mutable { out.backward(); };
+        run_op();  // warm-up: prime allocations and caches
+        device_sync(is_cuda);
+        run_timed_loop(state, run_op, is_cuda);
       })
-      ->MinWarmUpTime(kWarmUpTime)
-      ->Teardown([](const benchmark::State& state) {
-#ifdef LMP_ENABLE_CUDA
-        cudaStreamSynchronize(0);
-        cudaDeviceSynchronize();
-#endif
-      });
+      ->UseManualTime()
+      ->MinTime(kMinTimeSeconds);
 }

--- a/benchmarks/lamp3/reg_defs.hpp
+++ b/benchmarks/lamp3/reg_defs.hpp
@@ -13,25 +13,6 @@
 #include <cuda_runtime_api.h>
 #endif
 
-// Benchmark harness.
-//
-// Measures synchronized end-to-end per-op time using the same protocol as
-// PyTorch's operator_benchmark framework (benchmarks/torch/all_tests.py), so
-// the two CSVs are directly comparable:
-//
-//  - Inputs (and, for backward, the graph) are built once, outside the timed
-//    region.
-//  - Each timed iteration runs a batch of kOpsPerRound ops followed by ONE
-//    device synchronize, all inside the timed region; the reported time is
-//    elapsed / kOpsPerRound. Batching amortizes the fixed sync latency the
-//    same way operator_benchmark's inner loop does. Without the in-loop sync,
-//    CUDA benchmarks would only time host-side kernel enqueue and return
-//    before the GPU has done the work.
-//  - Backward is called repeatedly on the retained graph with no reduction:
-//    Lamp3's backward() seeds ones_like(out) internally, so the PyTorch side
-//    must match with `out.backward(torch.ones_like(out), retain_graph=True)`.
-//    Gradients accumulate across calls on both sides (no zero_grad).
-
 template <size_t N>
 using OperatorFunction = std::function<lmp::autograd::Variable(
     const std::array<lmp::autograd::Variable, N>&)>;
@@ -40,9 +21,6 @@ using InitializerFunction =
     std::function<std::array<lmp::autograd::Variable, N>(bool)>;
 
 const size_t kOpsPerRound = 100;
-// Accumulated manual time per benchmark. The manual time is per-op (round
-// elapsed / kOpsPerRound), so each benchmark's wall time is roughly
-// kMinTimeSeconds * kOpsPerRound.
 const double kMinTimeSeconds = 0.005;
 
 inline void device_sync(bool is_cuda) {
@@ -80,7 +58,7 @@ void register_forward(const std::string& name, const OperatorFunction<N>& op_fn,
           lmp::autograd::Variable result = op_fn(inputs);
           benchmark::DoNotOptimize(result);
         };
-        run_op();  // warm-up: prime allocations and caches
+        run_op();
         device_sync(is_cuda);
         run_timed_loop(state, run_op, is_cuda);
       })
@@ -98,7 +76,7 @@ void register_backward(const std::string& name,
         std::array<lmp::autograd::Variable, N> inputs = init_fn(true);
         lmp::autograd::Variable out = op_fn(inputs);
         auto run_op = [out]() mutable { out.backward(); };
-        run_op();  // warm-up: prime allocations and caches
+        run_op();
         device_sync(is_cuda);
         run_timed_loop(state, run_op, is_cuda);
       })

--- a/benchmarks/torch/all_tests.py
+++ b/benchmarks/torch/all_tests.py
@@ -6,6 +6,33 @@ import operator_benchmark as op_bench
 
 import torch
 
+from benchmark_pytorch import PyTorchOperatorTestCase
+
+
+# operator_benchmark times backward as `output.mean().backward()`, so its timed
+# region includes MeanBackward on top of the op's own backward. The Lamp3
+# harness measures a bare `out.backward()` (grad seeded with ones_like), so we
+# match it here: seed ones_like(output) once, then backward straight from output
+# with no reduction in the timed loop. grad magnitude differs from mean by 1/N,
+# which is irrelevant since we only measure time.
+def _seed_ones(self):
+    self._grad = torch.ones_like(self.output)
+
+
+def _run_backward_bare(self, num_runs, print_per_iter=False, gpu_sync=False,
+                       cuda_sync=False):
+    for _ in range(num_runs):
+        self.output.backward(self._grad, retain_graph=True)
+    if gpu_sync or cuda_sync:
+        if hasattr(torch, "accelerator"):
+            torch.accelerator.synchronize()
+        elif torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+
+PyTorchOperatorTestCase._output_mean = _seed_ones
+PyTorchOperatorTestCase.run_backward = _run_backward_bare
+
 """Microbenchmarks for all operators."""
 
 cross_product_config = {

--- a/benchmarks/torch/all_tests.py
+++ b/benchmarks/torch/all_tests.py
@@ -19,8 +19,9 @@ def _seed_ones(self):
     self._grad = torch.ones_like(self.output)
 
 
-def _run_backward_bare(self, num_runs, print_per_iter=False, gpu_sync=False,
-                       cuda_sync=False):
+def _run_backward_bare(
+    self, num_runs, print_per_iter=False, gpu_sync=False, cuda_sync=False
+):
     for _ in range(num_runs):
         self.output.backward(self._grad, retain_graph=True)
     if gpu_sync or cuda_sync:

--- a/csrc/src/tensor/cpu/reduct.cpp
+++ b/csrc/src/tensor/cpu/reduct.cpp
@@ -8,8 +8,7 @@ template <typename PtrList, typename OpFn>
 void vectorized_reduct_kernel(PtrList ptr_, OpFn fn_, size_t i, size_t axis,
                               const size_t* shape, const stride_t* strides) {
   stride_t outer = strides[axis];
-  // Equivalent to strides[axis - 1] for contiguous tensors, but defined for
-  // axis == 0 (strides[axis - 1] underflows to an out-of-bounds read).
+  // == strides[axis - 1] for contiguous tensors, but defined at axis == 0.
   stride_t inner = outer * static_cast<stride_t>(shape[axis]);
   stride_t idx = ((i / outer) * inner) + (i % outer);
 

--- a/csrc/src/tensor/cpu/reduct.cpp
+++ b/csrc/src/tensor/cpu/reduct.cpp
@@ -8,7 +8,9 @@ template <typename PtrList, typename OpFn>
 void vectorized_reduct_kernel(PtrList ptr_, OpFn fn_, size_t i, size_t axis,
                               const size_t* shape, const stride_t* strides) {
   stride_t outer = strides[axis];
-  stride_t inner = strides[axis - 1];
+  // Equivalent to strides[axis - 1] for contiguous tensors, but defined for
+  // axis == 0 (strides[axis - 1] underflows to an out-of-bounds read).
+  stride_t inner = outer * static_cast<stride_t>(shape[axis]);
   stride_t idx = ((i / outer) * inner) + (i % outer);
 
   auto incr = OpFn::kIdentity;

--- a/csrc/src/tensor/cuda/reduct.cu
+++ b/csrc/src/tensor/cuda/reduct.cu
@@ -16,7 +16,10 @@ __global__ void vectorized_reduct_kernel(PtrList ptr_, OpFn fn_, size_t size,
   for (size_t i = (blockIdx.x * blockDim.x) + threadIdx.x; i < size;
        i += gridDim.x * blockDim.x) {
     stride_t outer = strides[axis];
-    stride_t inner = strides[axis - 1];
+    // Equivalent to strides[axis - 1] for contiguous tensors, but defined for
+    // axis == 0 (strides[axis - 1] underflows to an out-of-bounds read that
+    // can fault and corrupt the CUDA context).
+    stride_t inner = outer * static_cast<stride_t>(shape[axis]);
     stride_t idx = ((i / outer) * inner) + (i % outer);
 
     auto incr = OpFn::kIdentity;

--- a/csrc/src/tensor/cuda/reduct.cu
+++ b/csrc/src/tensor/cuda/reduct.cu
@@ -16,9 +16,7 @@ __global__ void vectorized_reduct_kernel(PtrList ptr_, OpFn fn_, size_t size,
   for (size_t i = (blockIdx.x * blockDim.x) + threadIdx.x; i < size;
        i += gridDim.x * blockDim.x) {
     stride_t outer = strides[axis];
-    // Equivalent to strides[axis - 1] for contiguous tensors, but defined for
-    // axis == 0 (strides[axis - 1] underflows to an out-of-bounds read that
-    // can fault and corrupt the CUDA context).
+    // == strides[axis - 1] for contiguous tensors, but defined at axis == 0.
     stride_t inner = outer * static_cast<stride_t>(shape[axis]);
     stride_t idx = ((i / outer) * inner) + (i % outer);
 


### PR DESCRIPTION
## Summary and motivation

<!-- A short description of the change and the motivation for it.
     Link the related issue if there is one, e.g. "Closes #123". -->
Benchmark updates to fix bug for benchmarks calling cudaStreamSynchronize outside of the timing loop. 
Now creates batches and CudaStreamSynchronizes every batch, which matches pytorch benchmarks. 

## Test plan

<!-- e.g. "added a graph template", "new GTest case in tensor_tests",
     "ran `uv run pytest tests/` on CPU". If the change touches CUDA code,
     say whether you were able to test on a GPU or are relying on ci-gpu. -->

- [ ] All changes in PR are covered by tests
- [ ] Failures and edge cases tested
